### PR TITLE
chore(agent): add JS shim for agent pool so tests importing pool.js r…

### DIFF
--- a/packages/core/src/agent/pool.js
+++ b/packages/core/src/agent/pool.js
@@ -1,0 +1,8 @@
+// Shim to re-export the TypeScript implementation so imports that reference
+// "pool.js" resolve correctly in test/runtime environments that load .js paths.
+// This ensures tests that import "../src/agent/pool.js" find the actual implementation
+// in pool.ts and receive the expected named export `agentPool`.
+
+import { agentPool } from "./pool.ts"
+export { agentPool }
+export default agentPool


### PR DESCRIPTION
Summary

    This PR adds a tiny JavaScript shim file so test and runtime environments that import the agent pool implementation using a .js path (e.g., ../src/agent/pool.js) resolve correctly when the real implementation is authored in TypeScript (pool.ts).

Problem

    Some test runners, bundlers, or runtime loaders explicitly require or reference .js paths. The agent pool implementation lives in pool.ts, so imports that request pool.js fail with module-not-found or resolution errors, causing tests and some runtime fixtures to fail.

Solution

    Add a lightweight shim packages/core/src/agent/pool.js that re-exports the TypeScript implementation from pool.ts. The shim provides both the named export (agentPool) and a default export to maximize compatibility.

Changes

    New file: packages/core/src/agent/pool.js
