### PR TITLE
fix: stabilize TUI permissions and CI tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,6 +10,9 @@ jobs:
   typecheck-and-test:
     name: Typecheck & Test
     runs-on: ubuntu-latest
+    env:
+      HOME: ${{ runner.temp }}/aurict-home
+      AURICT_SNAPSHOT_DIR: ${{ runner.temp }}/aurict-snapshots
 
     steps:
       - uses: actions/checkout@v4

--- a/packages/cli/src/tui/App.tsx
+++ b/packages/cli/src/tui/App.tsx
@@ -83,6 +83,8 @@ interface Props {
   localServer?:    LocalServerStatus
 }
 
+const AUTO_CONTINUE_PROMPT = "Continue from where you stopped and finish the task without waiting for me."
+
 /**
  * Model görev ortasında metin bırakıp durdu mu?
  * Token kesintisi (açık kod bloğu) veya devam ifadesi varsa true döner.
@@ -98,6 +100,8 @@ function stalledMidTask(text: string): boolean {
   if (t.endsWith("…") || t.endsWith("...")) return true
   // "devam edeceğim / will continue / let me now / şimdi yapacağım" sonunda durma
   if (/(?:will\s+(?:now\s+)?continue|let me (?:now |proceed|continue)|devam edece[gğ]im|şimdi\s+\w+\s+yapaca[gğ]ım)[.…]?\s*$/i.test(t)) return true
+  // Açık kalan yönlendirme / liste / cümle kalıbı
+  if (/(?:next|then|after that|now I(?:'ll| will)|şimdi|sonra|devamında)[,:]?\s*$/i.test(t)) return true
   return false
 }
 
@@ -136,6 +140,7 @@ export function App({ initialProvider, initialModel, workdir, system, undercover
   const [model,      setModelState]    = useState(initialModel)
   const [effort,     setEffort]        = useState<number | undefined>(undefined)
   const [termCols,   setTermCols]      = useState(() => process.stdout.columns ?? 80)
+  const [termRows,   setTermRows]      = useState(() => process.stdout.rows ?? 24)
   const [messages,   setMessages]      = useState<DisplayMessage[]>([])
   const [input,      setInput]         = useState("")
   const [loading,    setLoading]       = useState(false)
@@ -149,6 +154,7 @@ export function App({ initialProvider, initialModel, workdir, system, undercover
   const [tasks,      setTasks]         = useState<Task[]>([])
   const [commandHistory, setCommandHistory] = useState<string[]>([])
   const [isStreaming,    setIsStreaming]     = useState(false)
+  const [startupBannerVisible, setStartupBannerVisible] = useState(true)
 
   // Streaming display — messages array'den ayrı tutulur (render storm önlenir)
   const [streamingText,   setStreamingText]   = useState<string | null>(null)
@@ -296,6 +302,7 @@ export function App({ initialProvider, initialModel, workdir, system, undercover
 
   // Auto-continue: model görev ortasında durduğunda otomatik devam
   const autoContinueRef  = useRef<{ needed: boolean; count: number }>({ needed: false, count: 0 })
+  const autoContinueSubmittingRef = useRef(false)
 
   // Adaptive throttle refs
   const streamTextRef    = useRef("")
@@ -324,11 +331,14 @@ export function App({ initialProvider, initialModel, workdir, system, undercover
     error:      tasks.filter(t => t.status === "error").length,
   }), [tasks])
   const sandboxBackend = useMemo(() => configuredSandboxBackend(), [])
-  const showStartupBanner = !viewingSubagentId
+  const showStartupBanner = !viewingSubagentId && startupBannerVisible
 
   // ── Subscriptions ─────────────────────────────────────────────────────────
   useEffect(() => {
-    const handler = () => setTermCols(process.stdout.columns ?? 80)
+    const handler = () => {
+      setTermCols(process.stdout.columns ?? 80)
+      setTermRows(process.stdout.rows ?? 24)
+    }
     process.stdout.on("resize", handler)
     return () => { process.stdout.off("resize", handler) }
   }, [])
@@ -1024,8 +1034,12 @@ export function App({ initialProvider, initialModel, workdir, system, undercover
     if (skipSubmitRef.current) { skipSubmitRef.current = false; return }
     let text = userInput.trim()
     if (!text) return
-    // Kullanıcı elle mesaj gönderince auto-continue sayacını sıfırla
-    autoContinueRef.current.count = 0
+    setStartupBannerVisible(false)
+    // Kullanıcı elle mesaj gönderince auto-continue sayacını sıfırla;
+    // otomatik devam mesajları kendi limitini korumalı.
+    const isAutoContinueSubmit = autoContinueSubmittingRef.current
+    autoContinueSubmittingRef.current = false
+    if (!isAutoContinueSubmit) autoContinueRef.current.count = 0
 
     // @path.ext[:symbol] syntax — file attachment or symbol context injection
     // @auth.ts          → attach whole file (image) or inline code for text files
@@ -1252,7 +1266,8 @@ export function App({ initialProvider, initialModel, workdir, system, undercover
           })
 
           // Stall tespiti: model görev ortasında metin bırakıp durduysa otomatik devam et
-          if (stalledMidTask(finalText) && autoContinueRef.current.count < 3) {
+          const likelyNeedsContinuation = stalledMidTask(finalText) || (!finalText.trim() && newMessages.length > 0)
+          if (likelyNeedsContinuation && autoContinueRef.current.count < 3) {
             autoContinueRef.current = { needed: true, count: autoContinueRef.current.count + 1 }
           } else {
             autoContinueRef.current.needed = false
@@ -1284,10 +1299,13 @@ export function App({ initialProvider, initialModel, workdir, system, undercover
       abortControllerRef.current = null
       setAttachments([])
       setQueuedInput((q) => {
-        const autoMsg = autoContinueRef.current.needed ? "continue" : undefined
+        const autoMsg = q === undefined && autoContinueRef.current.needed ? AUTO_CONTINUE_PROMPT : undefined
         autoContinueRef.current.needed = false
         const toSend = q ?? autoMsg
-        if (toSend) setTimeout(() => handleSubmit(toSend), 80)
+        if (toSend) {
+          if (autoMsg) autoContinueSubmittingRef.current = true
+          setTimeout(() => handleSubmit(toSend), 80)
+        }
         return undefined
       })
     }
@@ -1326,7 +1344,7 @@ export function App({ initialProvider, initialModel, workdir, system, undercover
 
         {/* Startup banner */}
         {showStartupBanner && (
-          <StartupBanner version={`v${CURRENT_VERSION}`} provider={provider} model={model} workdir={workdir} cols={termCols} />
+          <StartupBanner version={`v${CURRENT_VERSION}`} provider={provider} model={model} workdir={workdir} cols={termCols} rows={termRows} />
         )}
 
         {/* Update notification */}
@@ -1391,11 +1409,11 @@ export function App({ initialProvider, initialModel, workdir, system, undercover
         ))}
 
         {/* Canlı streaming + skeleton (metin gelmeden önce shimmer) */}
-        {!viewingSubagentId && (loading || streamingText || streamingReason || streamingError) && !activeTool && (
+        {!viewingSubagentId && (streamingText || streamingReason || streamingError || (loading && !activeTool)) && (
           <StreamingView
             text={streamingText}
             reasoning={streamingReason}
-            skeleton={loading && !streamingText && !streamingReason}
+            skeleton={loading && !activeTool && !streamingText && !streamingReason}
             {...(streamingError ? { error: streamingError } : {})}
           />
         )}

--- a/packages/cli/src/tui/CommandSuggest.tsx
+++ b/packages/cli/src/tui/CommandSuggest.tsx
@@ -11,6 +11,9 @@ import {
 } from "../commands/ui-metadata.js"
 
 const MAX_SHOW = 8
+const NAME_WIDTH = 16
+const CATEGORY_WIDTH = 10
+const ALIAS_WIDTH = 18
 
 interface Props {
   filter:    string         // "/" sonrası yazılan metin
@@ -62,13 +65,13 @@ export function CommandSuggest({ filter, commands, isActive, onExecute, onFill }
                 <Text color={sel ? theme.accent : theme.textDim}>{sel ? "▶" : " "}</Text>
                 <Text color={sel ? theme.accent : theme.textDim}>{commandIcon(cmd)}</Text>
                 <Text color={sel ? theme.accent : theme.textPrimary} bold={sel}>
-                  {"/" + cmd.name.padEnd(13)}
+                  {("/" + cmd.name).padEnd(NAME_WIDTH)}
                 </Text>
-                <Text color={theme.textDim} dimColor>{category.label.padEnd(8)}</Text>
-                {cmd.aliases?.length ? (
-                  <Text color={theme.textDim} dimColor>{cmd.aliases.slice(0, 3).map(a => `/${a}`).join(" ")}</Text>
-                ) : null}
-                <Text color={sel ? theme.textPrimary : theme.textDim} dimColor={!sel}>
+                <Text color={theme.textDim} dimColor>{category.label.padEnd(CATEGORY_WIDTH)}</Text>
+                <Text color={theme.textDim} dimColor>
+                  {(cmd.aliases?.slice(0, 3).map(a => `/${a}`).join(" ") ?? "").padEnd(ALIAS_WIDTH)}
+                </Text>
+                <Text color={sel ? theme.textPrimary : theme.textDim} dimColor={!sel} wrap="truncate-end">
                   {cmd.description}
                 </Text>
               </Box>

--- a/packages/cli/src/tui/MultilineInput.tsx
+++ b/packages/cli/src/tui/MultilineInput.tsx
@@ -38,7 +38,7 @@ function wordRight(line: string, col: number): number {
 }
 
 // Paste metni için: ANSI strip + \r normalizasyon + boyut sınırı + bracketed paste cleanup
-function sanitizePaste(raw: string): string {
+export function sanitizePaste(raw: string): string {
   return stripVTControlCharacters(raw)
     .replace(/\r\n/g, "\n")
     .replace(/\r/g, "\n")
@@ -87,7 +87,8 @@ export function MultilineInput({ value, onChange, onSubmit, disabled, history, o
     if (value !== joined && value !== prevValueRef.current) {
       const next = splitLines(value)
       setLines(next)
-      setCursor({ row: 0, col: 0 })
+      const lastRow = Math.max(0, next.length - 1)
+      setCursor({ row: lastRow, col: (next[lastRow] ?? "").length })
     }
     prevValueRef.current = value
   }, [value]) // eslint-disable-line react-hooks/exhaustive-deps
@@ -101,17 +102,18 @@ export function MultilineInput({ value, onChange, onSubmit, disabled, history, o
       onPasteTruncated?.(raw.length, pasted.length)
     }
     const pastedLines = pasted.split("\n")
+    const currentCursor = cursorRef.current
     setLines(prev => {
       const next   = [...prev]
-      const before = (next[cursor.row] ?? "").slice(0, cursor.col)
-      const after  = (next[cursor.row] ?? "").slice(cursor.col)
-      next[cursor.row] = before + pastedLines[0]!
+      const before = (next[currentCursor.row] ?? "").slice(0, currentCursor.col)
+      const after  = (next[currentCursor.row] ?? "").slice(currentCursor.col)
+      next[currentCursor.row] = before + pastedLines[0]!
       const rest = pastedLines.slice(1)
       if (rest.length > 0) {
         rest[rest.length - 1] = rest[rest.length - 1]! + after
-        next.splice(cursor.row + 1, 0, ...rest)
+        next.splice(currentCursor.row + 1, 0, ...rest)
       } else {
-        next[cursor.row] += after
+        next[currentCursor.row] += after
       }
       return next
     })
@@ -148,12 +150,17 @@ export function MultilineInput({ value, onChange, onSubmit, disabled, history, o
       return
     }
 
-    // ── Bracketed paste sequence fragment'lerini ignore et ─────────────
-    // Sanitize fonksiyonları bu karakterleri temizler, burada sadece ignore et
+    // ── Bracketed paste ────────────────────────────────────────────────
+    // Full paste events marker + content birlikte gelebilir; sadece marker
+    // fragment'leri yok sayılır, içerikli event paste olarak uygulanır.
     if (
-      input.includes("[200~") || input.includes("[201~") ||
-      input === "\x1b" || input === "\x1b["
+      input.includes("\x1b[200~") || input.includes("\x1b[201~") ||
+      input.includes("[200~") || input.includes("[201~")
     ) {
+      applyPaste(input)
+      return
+    }
+    if (input === "\x1b" || input === "\x1b[") {
       return
     }
 

--- a/packages/cli/src/tui/PermissionPrompt.tsx
+++ b/packages/cli/src/tui/PermissionPrompt.tsx
@@ -74,6 +74,7 @@ export function PermissionPrompt({ request, onDecide }: Props) {
   const risk      = riskLabel(request.level)
   const sandbox   = sandboxLabel(request)
   const isBashTool = request.tool === "bash" || request.tool === "shell"
+  const supportsDirectoryApproval = request.tool === "write" || request.tool === "edit" || request.tool === "apply_patch"
   const files = request.files ?? []
   const diff = request.diff
   const patchText = request.patch?.text
@@ -91,6 +92,7 @@ export function PermissionPrompt({ request, onDecide }: Props) {
   const options: Option[] = granularPatch
     ? [
         { id: "allow_partial", label: "Apply selected", hint: `${selectedCount}/${files.length} file${files.length === 1 ? "" : "s"}` },
+        { id: "allow_directory", label: "Apply + allow dirs", hint: "remember touched folders for this session" },
         { id: "allow_once", label: "Apply all once", hint: "ignore file selection for this patch" },
         { id: "deny", label: "Deny", hint: "reject patch, AI receives error", color: theme.error },
       ]
@@ -103,6 +105,7 @@ export function PermissionPrompt({ request, onDecide }: Props) {
       ]
     : [
         { id: "allow_once", label: "Allow once",       hint: "just this time, don't remember" },
+        ...(supportsDirectoryApproval ? [{ id: "allow_directory" as const, label: "Allow directory", hint: "remember this folder for session" }] : []),
         { id: "allow",      label: "Allow for session", hint: "remember until exit" },
         ...(isBashTool ? [{ id: "edit" as const, label: "Edit command", hint: "deny and move command to input", color: theme.accent }] : []),
         { id: "deny",       label: "Deny",              hint: "reject, AI continues with error",   color: theme.error },

--- a/packages/cli/src/tui/StartupBanner.tsx
+++ b/packages/cli/src/tui/StartupBanner.tsx
@@ -130,15 +130,17 @@ interface Props {
   model:    string
   workdir:  string
   cols?:    number
+  rows?:    number
 }
 
-export function StartupBanner({ version, provider, model, workdir, cols }: Props) {
+export function StartupBanner({ version, provider, model, workdir, cols, rows }: Props) {
   const theme = useTheme()
   const user  = process.env["USER"] || process.env["USERNAME"] || "user"
   const dir   = workdir.replace(process.env["HOME"] ?? "", "~")
 
   const tips = seededPick(TIP_POOL, 2)
   const isNarrow = cols !== undefined && cols < 85
+  const showFullLogo = cols === undefined || (cols >= 120 && (rows ?? 24) >= 30)
 
   // Re-render/resize durumunda repliğin değişmesini engellemek için mount anında bir kez seçilir
   const quote = React.useMemo(() => {
@@ -150,14 +152,15 @@ export function StartupBanner({ version, provider, model, workdir, cols }: Props
   if (isNarrow) {
     return (
       <VStack paddingX="md" paddingY="sm" gap="sm" borderStyle="round" borderColor={theme.borderDim}>
-        {/* Logo */}
-        <Center>
-          <VStack gap="none">
-            {ASCII_LOGO.map((row, i) => (
-              <Text key={i} color={row.color} bold>{row.text}</Text>
-            ))}
-          </VStack>
-        </Center>
+        {showFullLogo && (
+          <Center>
+            <VStack gap="none">
+              {ASCII_LOGO.map((row, i) => (
+                <Text key={i} color={row.color} bold>{row.text}</Text>
+              ))}
+            </VStack>
+          </Center>
+        )}
         <HStack justify="center" marginBottom="xs">
           <Text color="#475569">AURICT v{version}</Text>
         </HStack>
@@ -197,14 +200,15 @@ export function StartupBanner({ version, provider, model, workdir, cols }: Props
           <Text color={theme.textSecondary} bold>Welcome back {user}!</Text>
         </Center>
 
-        {/* Minimal aurict.png logosu */}
-        <Center>
-          <VStack gap="none">
-            {LOGO_AVATAR.map((row, i) => (
-              <Text key={i} color={row.color}>{row.text}</Text>
-            ))}
-          </VStack>
-        </Center>
+        {showFullLogo && (
+          <Center>
+            <VStack gap="none">
+              {LOGO_AVATAR.map((row, i) => (
+                <Text key={i} color={row.color}>{row.text}</Text>
+              ))}
+            </VStack>
+          </Center>
+        )}
 
         <VStack gap="none" align="center">
           <Text color={theme.textDim}>
@@ -227,12 +231,16 @@ export function StartupBanner({ version, provider, model, workdir, cols }: Props
         {/* Çok Geniş ekranlarda replik logonun yanına, orta genişlikte ise altına gelir */}
         {cols && cols >= 120 ? (
           <HStack gap="md" align="center">
-            <VStack gap="none">
-              {ASCII_LOGO.map((row, i) => (
-                <Text key={i} color={row.color} bold>{row.text}</Text>
-              ))}
-            </VStack>
-            <Divider orientation="vertical" color={theme.borderDim} />
+            {showFullLogo && (
+              <>
+                <VStack gap="none">
+                  {ASCII_LOGO.map((row, i) => (
+                    <Text key={i} color={row.color} bold>{row.text}</Text>
+                  ))}
+                </VStack>
+                <Divider orientation="vertical" color={theme.borderDim} />
+              </>
+            )}
             <VStack width={30} gap="none">
               <Text color={theme.accent} italic>"{quote}"</Text>
               <Text color={theme.textDim} dimColor>— Rick C-137</Text>
@@ -240,11 +248,13 @@ export function StartupBanner({ version, provider, model, workdir, cols }: Props
           </HStack>
         ) : (
           <VStack gap="xs">
-            <VStack gap="none">
-              {ASCII_LOGO.map((row, i) => (
-                <Text key={i} color={row.color} bold>{row.text}</Text>
-              ))}
-            </VStack>
+            {showFullLogo && (
+              <VStack gap="none">
+                {ASCII_LOGO.map((row, i) => (
+                  <Text key={i} color={row.color} bold>{row.text}</Text>
+                ))}
+              </VStack>
+            )}
             {cols && cols >= 85 && (
               <VStack marginTop="xs">
                 <Text color={theme.accent} italic>"{quote}"</Text>

--- a/packages/cli/test/tui.test.tsx
+++ b/packages/cli/test/tui.test.tsx
@@ -22,6 +22,7 @@ import { TaskFloatingPanel } from "../src/tui/TaskFloatingPanel.js"
 import { CommandPalette } from "../src/tui/CommandPalette.js"
 import { CommandSuggest } from "../src/tui/CommandSuggest.js"
 import { DesignWizard } from "../src/tui/DesignWizard.js"
+import { sanitizePaste } from "../src/tui/MultilineInput.js"
 import { parseSlashCommand } from "../src/commands/registry.js"
 import type { CommandDef } from "../src/commands/types.js"
 
@@ -387,6 +388,32 @@ describe("PermissionPrompt", () => {
     expect(frame).toContain("env scrubbed")
     expect(frame).toContain("$ rm -rf dist")
     expect(frame).toContain("Edit command")
+  })
+
+  it("offers directory approval for write requests", () => {
+    const { lastFrame } = render(
+      <PermissionPrompt
+        request={{
+          id: "req-write",
+          tool: "write",
+          pattern: "src/components/Button.tsx",
+          level: "warning",
+          reason: "Write a file",
+        }}
+        onDecide={() => {}}
+      />,
+    )
+
+    const frame = lastFrame() ?? ""
+    expect(frame).toContain("Allow directory")
+    expect(frame).toContain("remember this folder")
+  })
+})
+
+describe("MultilineInput", () => {
+  it("strips bracketed paste markers without dropping pasted content", () => {
+    expect(sanitizePaste("\x1b[200~first line\nsecond line\x1b[201~"))
+      .toBe("first line\nsecond line")
   })
 })
 

--- a/packages/core/src/agent/pool.ts
+++ b/packages/core/src/agent/pool.ts
@@ -3,6 +3,7 @@ import { hooks }          from "../hook/emitter.js"
 import { SessionManager } from "../session/manager.js"
 import { ensureWorkspace } from "./workspace.js"
 import { loadConfig }     from "../config/config.js"
+import type { Session }   from "../session/types.js"
 import type { WorkerRequest, WorkerMessage, WorkerControl, AgentType } from "./protocol.js"
 import { AGENT_TYPE_TOOLS } from "./protocol.js"
 
@@ -65,12 +66,20 @@ class AgentPool {
     this.recoverOrphanedSessions()
   }
 
-  private recoverOrphanedSessions() {
-    const running = SessionManager.list().filter(
-      (s) => (s as any).status === "running" && s.parentId !== null,
-    )
+  private listSubagentSessions(parentSessionId?: string): Session[] {
+    try {
+      return SessionManager.list().filter((s) =>
+        parentSessionId ? s.parentId === parentSessionId : s.parentId !== null,
+      )
+    } catch {
+      return []
+    }
+  }
+
+  private recoverOrphanedSessions(): void {
+    const running = this.listSubagentSessions().filter((s) => s.status === "running")
     for (const s of running) {
-      SessionManager.end(s.id, "crashed")
+      void SessionManager.end(s.id, "crashed").catch(() => {})
     }
   }
 
@@ -79,9 +88,7 @@ class AgentPool {
   }
 
   listSessions(parentSessionId?: string) {
-    return SessionManager.list().filter((s) =>
-      parentSessionId ? s.parentId === parentSessionId : s.parentId !== null,
-    )
+    return this.listSubagentSessions(parentSessionId)
   }
 
   onChange(cb: (agents: AgentInfo[]) => void): () => void {

--- a/packages/core/src/permission/store.ts
+++ b/packages/core/src/permission/store.ts
@@ -4,6 +4,7 @@ import { getToolCategory } from "./categories.js"
 
 // Session boyunca onaylanan/reddedilen izinleri tutar
 const approved = new Set<string>()
+const approvedDirs = new Set<string>()
 // Kategori bazlı session izinleri ("write" → "allow_session")
 const categoryApprovals = new Map<ToolCategory, CategoryPermission>()
 
@@ -11,15 +12,42 @@ function key(tool: string, pattern: string) {
   return `${tool}:${pattern}`
 }
 
+function normalizePathLike(path: string): string {
+  return path.replace(/\\/g, "/").replace(/\/+$/g, "") || "/"
+}
+
+function dirname(path: string): string {
+  const normalized = normalizePathLike(path)
+  if (normalized === "/") return "/"
+  const idx = normalized.lastIndexOf("/")
+  if (idx <= 0) return "."
+  return normalized.slice(0, idx)
+}
+
+function isInsideDir(path: string, dir: string): boolean {
+  const p = normalizePathLike(path)
+  const d = normalizePathLike(dir)
+  return p === d || p.startsWith(d.endsWith("/") ? d : `${d}/`)
+}
+
 export const PermissionStore = {
   isApproved(tool: string, pattern: string): boolean {
-    return approved.has(key(tool, pattern))
+    if (approved.has(key(tool, pattern))) return true
+    for (const dir of approvedDirs) {
+      const [dirTool, dirPath] = dir.split(":", 2)
+      if (dirTool === tool && dirPath && isInsideDir(pattern, dirPath)) return true
+    }
+    return false
   },
   approve(tool: string, pattern: string): void {
     approved.add(key(tool, pattern))
   },
+  approveDirectory(tool: string, pattern: string): void {
+    approvedDirs.add(key(tool, dirname(pattern)))
+  },
   clear(): void {
     approved.clear()
+    approvedDirs.clear()
     categoryApprovals.clear()
   },
 
@@ -39,6 +67,12 @@ export const PermissionStore = {
   },
   listCategoryApprovals(): Array<{ category: ToolCategory; perm: CategoryPermission }> {
     return [...categoryApprovals.entries()].map(([category, perm]) => ({ category, perm }))
+  },
+  listDirectoryApprovals(): Array<{ tool: string; dir: string }> {
+    return [...approvedDirs].map((entry) => {
+      const idx = entry.indexOf(":")
+      return { tool: entry.slice(0, idx), dir: entry.slice(idx + 1) }
+    })
   },
 }
 

--- a/packages/core/src/permission/types.ts
+++ b/packages/core/src/permission/types.ts
@@ -42,10 +42,11 @@ export interface PermissionRequest {
   }
 }
 
-// allow        = bu kez izin ver + session'a kaydet (tekrar sorma)
-// allow_once   = sadece bu kez izin ver, kaydetme
-// deny         = reddet, agent hata alır ama devam eder
-export type PermissionDecision = "allow" | "allow_once" | "allow_partial" | "deny"
+// allow           = bu kez izin ver + session'a kaydet (tekrar sorma)
+// allow_directory = bu kez izin ver + aynı klasör altında session boyunca hatırla
+// allow_once      = sadece bu kez izin ver, kaydetme
+// deny            = reddet, agent hata alır ama devam eder
+export type PermissionDecision = "allow" | "allow_directory" | "allow_once" | "allow_partial" | "deny"
 
 export interface PermissionResponse {
   decision: PermissionDecision

--- a/packages/core/src/tool/executor.ts
+++ b/packages/core/src/tool/executor.ts
@@ -187,6 +187,26 @@ function affectedPatchPaths(summary: PatchSummary): string[] {
   ))]
 }
 
+function isPermissionApproved(defId: string, pattern: string, patchSummary?: PatchSummary): boolean {
+  if (patchSummary) {
+    const paths = affectedPatchPaths(patchSummary)
+    return paths.length > 0 && paths.every((filePath) => PermissionStore.isApproved(defId, filePath))
+  }
+  return PermissionStore.isApproved(defId, pattern)
+}
+
+function approvePermission(defId: string, pattern: string, patchSummary: PatchSummary | undefined, directory: boolean): void {
+  if (patchSummary) {
+    for (const filePath of affectedPatchPaths(patchSummary)) {
+      if (directory) PermissionStore.approveDirectory(defId, filePath)
+      else PermissionStore.approve(defId, filePath)
+    }
+    return
+  }
+  if (directory) PermissionStore.approveDirectory(defId, pattern)
+  else PermissionStore.approve(defId, pattern)
+}
+
 export async function executeTool(
   def:     ToolDef,
   rawArgs: Record<string, unknown>,
@@ -252,6 +272,7 @@ export async function executeTool(
             return { output: "", error: `GateGuard: write to '${filePath}' denied by user.` }
           }
           if (userResponse.decision === "allow") PermissionStore.approve(def.id, filePath)
+          if (userResponse.decision === "allow_directory") PermissionStore.approveDirectory(def.id, filePath)
         }
       }
     }
@@ -302,6 +323,9 @@ export async function executeTool(
         }
         if (userResponse.decision === "allow") {
           for (const filePath of askPaths) PermissionStore.approve(def.id, filePath)
+        }
+        if (userResponse.decision === "allow_directory") {
+          for (const filePath of askPaths) PermissionStore.approveDirectory(def.id, filePath)
         }
       }
     }
@@ -362,7 +386,7 @@ export async function executeTool(
     return { output: "", error: `Permission denied: [${def.id}] ${pattern}` }
   }
 
-  if (decision === "ask" && !PermissionStore.isApproved(def.id, pattern)) {
+  if (decision === "ask" && !isPermissionApproved(def.id, pattern, patchSummary)) {
     // Kategori bazlı toplu onay — "Bu session boyunca tüm write işlemlerine izin ver" gibi
     if (PermissionStore.isCategoryApproved(def.id)) {
       // Kategori onayı var — bireysel onay gerekmez
@@ -404,8 +428,12 @@ export async function executeTool(
       }
       // allow_once → sadece bu kez, session'a kaydetme
       // allow      → session boyunca hatırla
+      // allow_directory → aynı klasör altında session boyunca hatırla
       if (userResponse.decision === "allow") {
-        PermissionStore.approve(def.id, pattern)
+        approvePermission(def.id, pattern, patchSummary, false)
+      }
+      if (userResponse.decision === "allow_directory") {
+        approvePermission(def.id, pattern, patchSummary, true)
       }
     }
   }

--- a/packages/core/test/permission.test.ts
+++ b/packages/core/test/permission.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect } from "bun:test"
 import { PermissionEvaluator } from "../src/permission/evaluator.js"
+import { PermissionStore } from "../src/permission/store.js"
 
 describe("PermissionEvaluator.evaluate", () => {
   // ── Always-allow tools ────────────────────────────────────────────────────
@@ -72,5 +73,19 @@ describe("PermissionEvaluator.evaluate", () => {
   it("wildcard * matches any value", () => {
     expect(PermissionEvaluator.evaluate("task", "anything")).toBe("allow")
     expect(PermissionEvaluator.evaluate("memory", "random-pattern")).toBe("allow")
+  })
+})
+
+describe("PermissionStore directory approvals", () => {
+  it("approves paths inside the remembered directory only", () => {
+    PermissionStore.clear()
+    PermissionStore.approveDirectory("write", "src/features/auth/login.ts")
+
+    expect(PermissionStore.isApproved("write", "src/features/auth/session.ts")).toBe(true)
+    expect(PermissionStore.isApproved("write", "src/features/auth/nested/token.ts")).toBe(true)
+    expect(PermissionStore.isApproved("write", "src/features/profile.ts")).toBe(false)
+    expect(PermissionStore.isApproved("edit", "src/features/auth/session.ts")).toBe(false)
+
+    PermissionStore.clear()
   })
 })


### PR DESCRIPTION
## Summary
- make agentPool session listing resilient to storage/init failures in CI
- keep startup banner from staying in the active TUI after first prompt, hide full logo outside large terminals, and stabilize slash command suggestion alignment
- preserve bracketed paste content, show thinking stream during active runs, and improve auto-continue handling
- add directory-scoped write approvals for write/edit/apply_patch without bypassing GateGuard denies
- isolate CI HOME/snapshot paths so tests do not depend on runner/user state

## Tests
- bun run typecheck
- env HOME=/tmp/aurict-test-home AURICT_SNAPSHOT_DIR=/tmp/aurict-test-snapshots bun test packages/core/test/ --timeout 30000
- env HOME=/tmp/aurict-test-home AURICT_SNAPSHOT_DIR=/tmp/aurict-test-snapshots bun test packages/cli/test/ --timeout 30000