### PR TITLE
Hide back button on onboarding's first step without layout shift

### DIFF
--- a/apps/desktop/src/renderer/screens/OnboardingScreen.tsx
+++ b/apps/desktop/src/renderer/screens/OnboardingScreen.tsx
@@ -82,8 +82,27 @@ export function OnboardingScreen({ onComplete }: Props) {
         {step === 4 && <><ChoiceGrid items={FONT_OPTIONS} selected={fontPair} onSelect={setFontPair} /><ExperiencePreview layout={layout} typography /></>}
 
         {error && <div role="alert" className="aur-inline-error">{error}</div>}
-        <div style={{ display: 'flex', justifyContent: 'space-between', marginTop: 20 }}>
-          <button onClick={() => setStep((current) => Math.max(0, current - 1))} disabled={step === 0} style={{ fontFamily: 'var(--font-mono)', fontSize: 12, padding: '9px 13px', color: step === 0 ? 'var(--text-disabled)' : 'var(--text)', background: 'transparent', border: '1px solid var(--border-strong)', borderRadius: 7, cursor: step === 0 ? 'default' : 'pointer' }}>← back</button>
+        <div style={{ display: 'flex', justifyContent: step === 0 ? 'flex-end' : 'space-between', marginTop: 20 }}>
+          {/**On step 0 there's nowhere to go back to, so the back button isn't
+           * rendered at all (rather than disabled) — a disabled-but-visible button
+           * caused "a brief visible flash" when navigating back to step 0, even in
+           * the packaged production build. justifyContent switches to flex-end
+           * when the button is absent so the continue button doesn't jump position
+           * (no back button = no second flex child to space-between against).*/}
+          {step > 0 && (
+            <button
+              onClick={() => setStep((current) => Math.max(0, current - 1))}
+              style={{
+                fontFamily: 'var(--font-mono)',
+                fontSize: 12,
+                padding: '9px 13px',
+                color: 'var(--text)',
+                background: 'transparent',
+                border: '1px solid var(--border-strong)',
+                borderRadius: 7,
+                cursor: 'pointer' 
+              }}>← back</button>
+          )}
           {step < STEPS.length - 1 ? <button onClick={() => setStep((current) => current + 1)} disabled={step === 2 && (!modelPreference.providerId || !modelPreference.modelId)} style={primaryButton}>continue →</button> : <button onClick={() => { void finish(); }} disabled={saving} style={primaryButton}>{saving ? 'saving…' : 'enter Aurict →'}</button>}
         </div>
       </div>


### PR DESCRIPTION
## Problem
On the onboarding wizard's first step, the "back" button was rendered
disabled (grayed out) rather than hidden — there's nowhere to go back
to at that point, which was confusing. Noticed while testing #5.

## Fix
- The back button is no longer rendered at all on step 0 (instead of
  disabled).
- The container's `justifyContent` switches from `space-between` to
  `flex-end` when the button is absent, so the "continue" button
  doesn't shift position between step 0 and later steps.

## Testing
- Manually tested on Windows, both dev mode and a packaged production
  build (`bun run package`) — no layout shift, no visual flicker when
  navigating back to step 0.
- Manually tested on Linux (WSL2), same steps — confirmed working
  correctly.
- Ran lint, typecheck, unit tests, and a full package build locally.

## Next Step
The main Titlebar's drag region is very narrow (most of the bar is
marked no-drag for nav/status content), and the "More" overflow menu
doesn't render visibly because its parent (.aur-titlebar-nav) has
overflow: hidden, clipping the dropdown. Both are separate,
pre-existing issues unrelated to onboarding — planning a follow-up PR.