### PR TITLE
MOB-RC-02: Add strict remote model fixture tests

### DIFF
--- a/mobile/lib/remote/mobile_remote_models.dart
+++ b/mobile/lib/remote/mobile_remote_models.dart
@@ -10,13 +10,46 @@ class MobileRemoteProtocol {
   final List<String> eventTypes;
 
   factory MobileRemoteProtocol.fromJson(Map<String, dynamic> json) {
+    final version = json['version'];
+    if (version is! int || version != 1) {
+      throw const FormatException(
+        'MobileRemoteProtocol: version must be integer 1',
+      );
+    }
+
+    final backendCarriesPayload = json['backendCarriesPayload'];
+    if (backendCarriesPayload is! bool) {
+      throw const FormatException(
+        'MobileRemoteProtocol: backendCarriesPayload must be a boolean',
+      );
+    }
+    if (backendCarriesPayload) {
+      throw const FormatException(
+        'MobileRemoteProtocol: backendCarriesPayload must be false for P2P data plane',
+      );
+    }
+
+    final rawEventTypes = json['eventTypes'];
+    if (rawEventTypes is! List || rawEventTypes.isEmpty) {
+      throw const FormatException(
+        'MobileRemoteProtocol: eventTypes must be a non-empty list',
+      );
+    }
+
+    final eventTypes = <String>[];
+    for (final item in rawEventTypes) {
+      if (item is! String || item.trim().isEmpty) {
+        throw const FormatException(
+          'MobileRemoteProtocol: eventTypes items must be non-empty strings',
+        );
+      }
+      eventTypes.add(item);
+    }
+
     return MobileRemoteProtocol(
-      version: int.tryParse(json['version']?.toString() ?? '') ?? 1,
-      backendCarriesPayload: json['backendCarriesPayload'] == true,
-      eventTypes: [
-        for (final item in (json['eventTypes'] as List? ?? const []))
-          item.toString(),
-      ],
+      version: version,
+      backendCarriesPayload: backendCarriesPayload,
+      eventTypes: List<String>.unmodifiable(eventTypes),
     );
   }
 }
@@ -53,32 +86,161 @@ class MobileRemoteSession {
   final DateTime lastHeartbeatAt;
 
   factory MobileRemoteSession.fromJson(Map<String, dynamic> json) {
+    final id = json['id'];
+    if (id is! String || id.trim().isEmpty) {
+      throw const FormatException('MobileRemoteSession: missing or empty id');
+    }
+
+    final desktopDeviceId = json['desktopDeviceId'];
+    if (desktopDeviceId is! String || desktopDeviceId.trim().isEmpty) {
+      throw const FormatException(
+        'MobileRemoteSession: missing or empty desktopDeviceId',
+      );
+    }
+
+    final protocolVersion = json['protocolVersion'];
+    if (protocolVersion is! int || protocolVersion != 1) {
+      throw const FormatException(
+        'MobileRemoteSession: protocolVersion must be integer 1',
+      );
+    }
+
+    final status = json['status'];
+    if (status is! String || status.trim().isEmpty) {
+      throw const FormatException(
+        'MobileRemoteSession: missing or empty status',
+      );
+    }
+
+    final connectionMode = json['connectionMode'];
+    if (connectionMode is! String || connectionMode != 'webrtc') {
+      throw const FormatException(
+        'MobileRemoteSession: connectionMode must be "webrtc"',
+      );
+    }
+
+    final rawSignedOffer = json['signedOffer'];
+    if (rawSignedOffer is! Map<String, dynamic>) {
+      throw const FormatException(
+        'MobileRemoteSession: missing or invalid signedOffer Map',
+      );
+    }
+    final signedOffer = MobileSignalEnvelope.fromJson(rawSignedOffer);
+    if (signedOffer.type != 'offer') {
+      throw const FormatException(
+        'MobileRemoteSession: signedOffer type must be "offer"',
+      );
+    }
+
+    String? acceptedByDeviceId;
+    final rawAcceptedByDeviceId = json['acceptedByDeviceId'];
+    if (rawAcceptedByDeviceId != null) {
+      if (rawAcceptedByDeviceId is! String ||
+          rawAcceptedByDeviceId.trim().isEmpty) {
+        throw const FormatException(
+          'MobileRemoteSession: acceptedByDeviceId must be a non-empty string when present',
+        );
+      }
+      acceptedByDeviceId = rawAcceptedByDeviceId;
+    }
+
+    MobileSignalEnvelope? signedAnswer;
+    final rawSignedAnswer = json['signedAnswer'];
+    if (rawSignedAnswer != null) {
+      if (rawSignedAnswer is! Map<String, dynamic>) {
+        throw const FormatException(
+          'MobileRemoteSession: signedAnswer must be a Map when present',
+        );
+      }
+      signedAnswer = MobileSignalEnvelope.fromJson(rawSignedAnswer);
+      if (signedAnswer.type != 'answer') {
+        throw const FormatException(
+          'MobileRemoteSession: signedAnswer type must be "answer"',
+        );
+      }
+    }
+
+    final rawResumeAvailable = json['resumeAvailable'];
+    final bool resumeAvailable;
+    if (rawResumeAvailable != null) {
+      if (rawResumeAvailable is! bool) {
+        throw const FormatException(
+          'MobileRemoteSession: resumeAvailable must be a boolean when present',
+        );
+      }
+      resumeAvailable = rawResumeAvailable;
+    } else {
+      resumeAvailable = false;
+    }
+
+    final lastSequence = json['lastSequence'];
+    if (lastSequence is! int || lastSequence < 0) {
+      throw const FormatException(
+        'MobileRemoteSession: lastSequence must be a non-negative integer',
+      );
+    }
+
+    final maxIdleSeconds = json['maxIdleSeconds'];
+    if (maxIdleSeconds is! int || maxIdleSeconds <= 0) {
+      throw const FormatException(
+        'MobileRemoteSession: maxIdleSeconds must be a positive integer',
+      );
+    }
+
+    final rawExpiresAt = json['expiresAt'];
+    if (rawExpiresAt is! String) {
+      throw const FormatException(
+        'MobileRemoteSession: missing expiresAt timestamp string',
+      );
+    }
+    final trimmedExpiresAt = rawExpiresAt.trim();
+    if (!RegExp(r'(?:Z|[+-]\d{2}(?::?\d{2})?)$').hasMatch(trimmedExpiresAt)) {
+      throw const FormatException(
+        'MobileRemoteSession: expiresAt must include explicit timezone',
+      );
+    }
+    final expiresAt = DateTime.tryParse(trimmedExpiresAt);
+    if (expiresAt == null) {
+      throw const FormatException(
+        'MobileRemoteSession: invalid expiresAt timestamp',
+      );
+    }
+
+    final rawLastHeartbeatAt = json['lastHeartbeatAt'];
+    if (rawLastHeartbeatAt is! String) {
+      throw const FormatException(
+        'MobileRemoteSession: missing lastHeartbeatAt timestamp string',
+      );
+    }
+    final trimmedLastHeartbeatAt = rawLastHeartbeatAt.trim();
+    if (!RegExp(
+      r'(?:Z|[+-]\d{2}(?::?\d{2})?)$',
+    ).hasMatch(trimmedLastHeartbeatAt)) {
+      throw const FormatException(
+        'MobileRemoteSession: lastHeartbeatAt must include explicit timezone',
+      );
+    }
+    final lastHeartbeatAt = DateTime.tryParse(trimmedLastHeartbeatAt);
+    if (lastHeartbeatAt == null) {
+      throw const FormatException(
+        'MobileRemoteSession: invalid lastHeartbeatAt timestamp',
+      );
+    }
+
     return MobileRemoteSession(
-      id: json['id'].toString(),
-      desktopDeviceId: json['desktopDeviceId'].toString(),
-      protocolVersion:
-          int.tryParse(json['protocolVersion']?.toString() ?? '') ?? 1,
-      status: json['status']?.toString() ?? 'unknown',
-      connectionMode: json['connectionMode']?.toString() ?? 'webrtc',
-      signedOffer: MobileSignalEnvelope.fromJson(
-        json['signedOffer'] as Map<String, dynamic>,
-      ),
-      acceptedByDeviceId: json['acceptedByDeviceId']?.toString(),
-      signedAnswer: json['signedAnswer'] is Map<String, dynamic>
-          ? MobileSignalEnvelope.fromJson(
-              json['signedAnswer'] as Map<String, dynamic>,
-            )
-          : null,
-      resumeAvailable: json['resumeAvailable'] == true,
-      lastSequence: int.tryParse(json['lastSequence']?.toString() ?? '') ?? 0,
-      maxIdleSeconds:
-          int.tryParse(json['maxIdleSeconds']?.toString() ?? '') ?? 90,
-      expiresAt:
-          DateTime.tryParse(json['expiresAt']?.toString() ?? '') ??
-          DateTime.now(),
-      lastHeartbeatAt:
-          DateTime.tryParse(json['lastHeartbeatAt']?.toString() ?? '') ??
-          DateTime.now(),
+      id: id,
+      desktopDeviceId: desktopDeviceId,
+      protocolVersion: protocolVersion,
+      status: status,
+      connectionMode: connectionMode,
+      signedOffer: signedOffer,
+      acceptedByDeviceId: acceptedByDeviceId,
+      signedAnswer: signedAnswer,
+      resumeAvailable: resumeAvailable,
+      lastSequence: lastSequence,
+      maxIdleSeconds: maxIdleSeconds,
+      expiresAt: expiresAt,
+      lastHeartbeatAt: lastHeartbeatAt,
     );
   }
 }
@@ -103,15 +265,64 @@ class MobileSignalEnvelope {
   final String signature;
 
   factory MobileSignalEnvelope.fromJson(Map<String, dynamic> json) {
+    final version = json['version'];
+    if (version is! int || version != 1) {
+      throw const FormatException(
+        'MobileSignalEnvelope: version must be integer 1',
+      );
+    }
+
+    final sessionProtocolVersion = json['sessionProtocolVersion'];
+    if (sessionProtocolVersion is! int || sessionProtocolVersion != 1) {
+      throw const FormatException(
+        'MobileSignalEnvelope: sessionProtocolVersion must be integer 1',
+      );
+    }
+
+    final type = json['type'];
+    if (type is! String || (type != 'offer' && type != 'answer')) {
+      throw const FormatException(
+        'MobileSignalEnvelope: type must be "offer" or "answer"',
+      );
+    }
+
+    final transport = json['transport'];
+    if (transport is! String || transport != 'webrtc') {
+      throw const FormatException(
+        'MobileSignalEnvelope: transport must be "webrtc"',
+      );
+    }
+
+    final payload = json['payload'];
+    if (payload is! String || payload.trim().isEmpty) {
+      throw const FormatException(
+        'MobileSignalEnvelope: payload must be a non-empty string',
+      );
+    }
+
+    final signingKeyFingerprint = json['signingKeyFingerprint'];
+    if (signingKeyFingerprint is! String ||
+        signingKeyFingerprint.trim().isEmpty) {
+      throw const FormatException(
+        'MobileSignalEnvelope: missing or empty signingKeyFingerprint',
+      );
+    }
+
+    final signature = json['signature'];
+    if (signature is! String || signature.trim().isEmpty) {
+      throw const FormatException(
+        'MobileSignalEnvelope: missing or empty signature',
+      );
+    }
+
     return MobileSignalEnvelope(
-      version: int.tryParse(json['version']?.toString() ?? '') ?? 1,
-      sessionProtocolVersion:
-          int.tryParse(json['sessionProtocolVersion']?.toString() ?? '') ?? 1,
-      type: json['type']?.toString() ?? 'offer',
-      transport: json['transport']?.toString() ?? 'webrtc',
-      payload: json['payload']?.toString() ?? '',
-      signingKeyFingerprint: json['signingKeyFingerprint']?.toString() ?? '',
-      signature: json['signature']?.toString() ?? '',
+      version: version,
+      sessionProtocolVersion: sessionProtocolVersion,
+      type: type,
+      transport: transport,
+      payload: payload,
+      signingKeyFingerprint: signingKeyFingerprint,
+      signature: signature,
     );
   }
 
@@ -142,15 +353,61 @@ class MobileTurnCredential {
   final DateTime expiresAt;
 
   factory MobileTurnCredential.fromJson(Map<String, dynamic> json) {
+    final rawUrls = json['urls'];
+    if (rawUrls is! List || rawUrls.isEmpty) {
+      throw const FormatException(
+        'MobileTurnCredential: urls must be a non-empty list',
+      );
+    }
+
+    final urls = <String>[];
+    for (final item in rawUrls) {
+      if (item is! String || item.trim().isEmpty) {
+        throw const FormatException(
+          'MobileTurnCredential: url items must be non-empty strings',
+        );
+      }
+      urls.add(item);
+    }
+
+    final username = json['username'];
+    if (username is! String || username.trim().isEmpty) {
+      throw const FormatException(
+        'MobileTurnCredential: missing or empty username',
+      );
+    }
+
+    final credential = json['credential'];
+    if (credential is! String || credential.trim().isEmpty) {
+      throw const FormatException(
+        'MobileTurnCredential: missing or empty credential',
+      );
+    }
+
+    final rawExpiresAt = json['expiresAt'];
+    if (rawExpiresAt is! String) {
+      throw const FormatException(
+        'MobileTurnCredential: missing expiresAt timestamp string',
+      );
+    }
+    final trimmedExpiresAt = rawExpiresAt.trim();
+    if (!RegExp(r'(?:Z|[+-]\d{2}(?::?\d{2})?)$').hasMatch(trimmedExpiresAt)) {
+      throw const FormatException(
+        'MobileTurnCredential: expiresAt must include explicit timezone',
+      );
+    }
+    final expiresAt = DateTime.tryParse(trimmedExpiresAt);
+    if (expiresAt == null) {
+      throw const FormatException(
+        'MobileTurnCredential: invalid expiresAt timestamp',
+      );
+    }
+
     return MobileTurnCredential(
-      urls: [
-        for (final item in (json['urls'] as List? ?? const [])) item.toString(),
-      ],
-      username: json['username']?.toString() ?? '',
-      credential: json['credential']?.toString() ?? '',
-      expiresAt:
-          DateTime.tryParse(json['expiresAt']?.toString() ?? '') ??
-          DateTime.now(),
+      urls: List<String>.unmodifiable(urls),
+      username: username,
+      credential: credential,
+      expiresAt: expiresAt,
     );
   }
 }

--- a/mobile/test/fixtures/remote/invalid_protocol_unsupported.json
+++ b/mobile/test/fixtures/remote/invalid_protocol_unsupported.json
@@ -1,0 +1,7 @@
+{
+  "version": 99,
+  "backendCarriesPayload": false,
+  "eventTypes": [
+    "prompt.submit"
+  ]
+}

--- a/mobile/test/fixtures/remote/invalid_session_missing_signed_offer.json
+++ b/mobile/test/fixtures/remote/invalid_session_missing_signed_offer.json
@@ -1,0 +1,12 @@
+{
+  "id": "session-test-002",
+  "desktopDeviceId": "device-test-cli-001",
+  "protocolVersion": 1,
+  "status": "available",
+  "connectionMode": "webrtc",
+  "signedOffer": null,
+  "lastSequence": 0,
+  "maxIdleSeconds": 90,
+  "expiresAt": "2026-08-17T12:00:00.000Z",
+  "lastHeartbeatAt": "2026-08-17T11:55:00.000Z"
+}

--- a/mobile/test/fixtures/remote/invalid_signal_envelope_empty_payload.json
+++ b/mobile/test/fixtures/remote/invalid_signal_envelope_empty_payload.json
@@ -1,0 +1,9 @@
+{
+  "version": 1,
+  "sessionProtocolVersion": 1,
+  "type": "offer",
+  "transport": "webrtc",
+  "payload": "",
+  "signingKeyFingerprint": "fp_test_device_001",
+  "signature": "synthetic-sig-offer-001"
+}

--- a/mobile/test/fixtures/remote/invalid_turn_credential_expiry.json
+++ b/mobile/test/fixtures/remote/invalid_turn_credential_expiry.json
@@ -1,0 +1,8 @@
+{
+  "urls": [
+    "turn:turn.example.invalid:3478"
+  ],
+  "username": "synthetic-turn-user",
+  "credential": "synthetic-turn-credential",
+  "expiresAt": "not-a-valid-date"
+}

--- a/mobile/test/fixtures/remote/valid_protocol.json
+++ b/mobile/test/fixtures/remote/valid_protocol.json
@@ -1,0 +1,16 @@
+{
+  "version": 1,
+  "backendCarriesPayload": false,
+  "eventTypes": [
+    "prompt.submit",
+    "terminal.output",
+    "agent.status",
+    "tool.call",
+    "tool.result.summary",
+    "interrupt",
+    "resume",
+    "heartbeat",
+    "close",
+    "error"
+  ]
+}

--- a/mobile/test/fixtures/remote/valid_session.json
+++ b/mobile/test/fixtures/remote/valid_session.json
@@ -1,0 +1,23 @@
+{
+  "id": "session-test-001",
+  "desktopDeviceId": "device-test-cli-001",
+  "protocolVersion": 1,
+  "status": "available",
+  "connectionMode": "webrtc",
+  "signedOffer": {
+    "version": 1,
+    "sessionProtocolVersion": 1,
+    "type": "offer",
+    "transport": "webrtc",
+    "payload": "v=0\r\no=- 123456 2 IN IP4 127.0.0.1\r\ns=-\r\nt=0 0\r\n",
+    "signingKeyFingerprint": "fp_test_device_001",
+    "signature": "synthetic-sig-offer-001"
+  },
+  "acceptedByDeviceId": null,
+  "signedAnswer": null,
+  "resumeAvailable": false,
+  "lastSequence": 0,
+  "maxIdleSeconds": 90,
+  "expiresAt": "2026-08-17T12:00:00.000Z",
+  "lastHeartbeatAt": "2026-08-17T11:55:00.000Z"
+}

--- a/mobile/test/fixtures/remote/valid_signal_envelope.json
+++ b/mobile/test/fixtures/remote/valid_signal_envelope.json
@@ -1,0 +1,9 @@
+{
+  "version": 1,
+  "sessionProtocolVersion": 1,
+  "type": "offer",
+  "transport": "webrtc",
+  "payload": "v=0\r\no=- 123456 2 IN IP4 127.0.0.1\r\ns=-\r\nt=0 0\r\na=sendrecv\r\n",
+  "signingKeyFingerprint": "fp_test_device_001",
+  "signature": "synthetic-sig-offer-001"
+}

--- a/mobile/test/fixtures/remote/valid_turn_credential.json
+++ b/mobile/test/fixtures/remote/valid_turn_credential.json
@@ -1,0 +1,9 @@
+{
+  "urls": [
+    "turn:turn.example.invalid:3478",
+    "turns:turn.example.invalid:5349"
+  ],
+  "username": "synthetic-turn-user",
+  "credential": "synthetic-turn-credential",
+  "expiresAt": "2026-08-17T12:00:00.000Z"
+}

--- a/mobile/test/remote/mobile_remote_models_test.dart
+++ b/mobile/test/remote/mobile_remote_models_test.dart
@@ -1,0 +1,302 @@
+import 'dart:convert';
+import 'dart:io';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:aurict_mobile/remote/mobile_remote_models.dart';
+
+Map<String, dynamic> _readFixture(String filename) {
+  final file = File('test/fixtures/remote/$filename');
+  return jsonDecode(file.readAsStringSync()) as Map<String, dynamic>;
+}
+
+void main() {
+  group('MobileRemoteProtocol', () {
+    test('parses valid protocol fixture correctly', () {
+      final json = _readFixture('valid_protocol.json');
+      final protocol = MobileRemoteProtocol.fromJson(json);
+
+      expect(protocol.version, 1);
+      expect(protocol.backendCarriesPayload, isFalse);
+      expect(protocol.eventTypes, contains('prompt.submit'));
+      expect(protocol.eventTypes.length, 10);
+    });
+
+    test(
+      'strict validation rejects invalid version, backendCarriesPayload, or eventTypes',
+      () {
+        Map<String, dynamic> valid() => _readFixture('valid_protocol.json');
+
+        final invalidCases = <String, Map<String, dynamic>>{
+          'missing version': valid()..remove('version'),
+          'string version': valid()..['version'] = '1',
+          'double version': valid()..['version'] = 1.0,
+          'zero version': valid()..['version'] = 0,
+          'unsupported version': valid()..['version'] = 99,
+          'missing backendCarriesPayload': valid()
+            ..remove('backendCarriesPayload'),
+          'non-bool backendCarriesPayload': valid()
+            ..['backendCarriesPayload'] = 'false',
+          'backendCarriesPayload true (security violation)': valid()
+            ..['backendCarriesPayload'] = true,
+          'missing eventTypes': valid()..remove('eventTypes'),
+          'non-list eventTypes': valid()..['eventTypes'] = 'not-a-list',
+          'empty eventTypes': valid()..['eventTypes'] = <dynamic>[],
+          'non-string item in eventTypes': valid()
+            ..['eventTypes'] = <dynamic>[123],
+          'empty string item in eventTypes': valid()
+            ..['eventTypes'] = <dynamic>[''],
+        };
+
+        for (final entry in invalidCases.entries) {
+          expect(
+            () => MobileRemoteProtocol.fromJson(entry.value),
+            throwsFormatException,
+            reason: 'Case "${entry.key}" should throw FormatException',
+          );
+        }
+      },
+    );
+
+    test('rejects unsupported protocol fixture', () {
+      final json = _readFixture('invalid_protocol_unsupported.json');
+      expect(() => MobileRemoteProtocol.fromJson(json), throwsFormatException);
+    });
+  });
+
+  group('MobileSignalEnvelope', () {
+    test(
+      'parses valid signal envelope fixture and executes toJson round-trip',
+      () {
+        final json = _readFixture('valid_signal_envelope.json');
+        final envelope = MobileSignalEnvelope.fromJson(json);
+
+        expect(envelope.version, 1);
+        expect(envelope.sessionProtocolVersion, 1);
+        expect(envelope.type, 'offer');
+        expect(envelope.transport, 'webrtc');
+        expect(envelope.payload, startsWith('v=0'));
+        expect(envelope.signingKeyFingerprint, 'fp_test_device_001');
+        expect(envelope.signature, 'synthetic-sig-offer-001');
+
+        final serialized = envelope.toJson();
+        final roundTrip = MobileSignalEnvelope.fromJson(serialized);
+        expect(roundTrip.version, envelope.version);
+        expect(
+          roundTrip.sessionProtocolVersion,
+          envelope.sessionProtocolVersion,
+        );
+        expect(roundTrip.type, envelope.type);
+        expect(roundTrip.transport, envelope.transport);
+        expect(roundTrip.payload, envelope.payload);
+        expect(roundTrip.signingKeyFingerprint, envelope.signingKeyFingerprint);
+        expect(roundTrip.signature, envelope.signature);
+      },
+    );
+
+    test('accepts answer type', () {
+      final json = _readFixture('valid_signal_envelope.json')
+        ..['type'] = 'answer';
+      final envelope = MobileSignalEnvelope.fromJson(json);
+      expect(envelope.type, 'answer');
+    });
+
+    test('strict validation rejects invalid envelope fields', () {
+      Map<String, dynamic> valid() =>
+          _readFixture('valid_signal_envelope.json');
+
+      final invalidCases = <String, Map<String, dynamic>>{
+        'missing version': valid()..remove('version'),
+        'unsupported version': valid()..['version'] = 2,
+        'missing sessionProtocolVersion': valid()
+          ..remove('sessionProtocolVersion'),
+        'string sessionProtocolVersion': valid()
+          ..['sessionProtocolVersion'] = '1',
+        'unsupported sessionProtocolVersion': valid()
+          ..['sessionProtocolVersion'] = 2,
+        'missing type': valid()..remove('type'),
+        'unsupported type': valid()..['type'] = 'candidate',
+        'missing transport': valid()..remove('transport'),
+        'tunnel transport': valid()..['transport'] = 'tunnel',
+        'lan transport': valid()..['transport'] = 'lan',
+        'unsupported transport': valid()..['transport'] = 'udp',
+        'missing payload': valid()..remove('payload'),
+        'empty payload': valid()..['payload'] = '',
+        'whitespace-only payload': valid()..['payload'] = '   ',
+        'missing signingKeyFingerprint': valid()
+          ..remove('signingKeyFingerprint'),
+        'empty signingKeyFingerprint': valid()..['signingKeyFingerprint'] = '',
+        'missing signature': valid()..remove('signature'),
+        'empty signature': valid()..['signature'] = '',
+      };
+
+      for (final entry in invalidCases.entries) {
+        expect(
+          () => MobileSignalEnvelope.fromJson(entry.value),
+          throwsFormatException,
+          reason: 'Case "${entry.key}" should throw FormatException',
+        );
+      }
+    });
+
+    test('rejects empty payload fixture', () {
+      final json = _readFixture('invalid_signal_envelope_empty_payload.json');
+      expect(() => MobileSignalEnvelope.fromJson(json), throwsFormatException);
+    });
+  });
+
+  group('MobileRemoteSession', () {
+    test('parses valid session fixture correctly', () {
+      final json = _readFixture('valid_session.json');
+      final session = MobileRemoteSession.fromJson(json);
+
+      expect(session.id, 'session-test-001');
+      expect(session.desktopDeviceId, 'device-test-cli-001');
+      expect(session.protocolVersion, 1);
+      expect(session.status, 'available');
+      expect(session.connectionMode, 'webrtc');
+      expect(session.signedOffer.type, 'offer');
+      expect(session.signedOffer.transport, 'webrtc');
+      expect(session.acceptedByDeviceId, isNull);
+      expect(session.signedAnswer, isNull);
+      expect(session.resumeAvailable, isFalse);
+      expect(session.lastSequence, 0);
+      expect(session.maxIdleSeconds, 90);
+      expect(session.expiresAt, DateTime.parse('2026-08-17T12:00:00.000Z'));
+      expect(
+        session.lastHeartbeatAt,
+        DateTime.parse('2026-08-17T11:55:00.000Z'),
+      );
+    });
+
+    test(
+      'parses session with optional acceptedByDeviceId, signedAnswer, and resumeAvailable',
+      () {
+        final json = _readFixture('valid_session.json')
+          ..['acceptedByDeviceId'] = 'device-test-mobile-001'
+          ..['signedAnswer'] = (_readFixture('valid_signal_envelope.json')
+            ..['type'] = 'answer')
+          ..['resumeAvailable'] = true;
+
+        final session = MobileRemoteSession.fromJson(json);
+        expect(session.acceptedByDeviceId, 'device-test-mobile-001');
+        expect(session.signedAnswer?.type, 'answer');
+        expect(session.resumeAvailable, isTrue);
+      },
+    );
+
+    test('strict validation rejects invalid session fields', () {
+      Map<String, dynamic> valid() => _readFixture('valid_session.json');
+
+      final invalidCases = <String, Map<String, dynamic>>{
+        'missing id': valid()..remove('id'),
+        'empty id': valid()..['id'] = '',
+        'whitespace id': valid()..['id'] = '   ',
+        'missing desktopDeviceId': valid()..remove('desktopDeviceId'),
+        'empty desktopDeviceId': valid()..['desktopDeviceId'] = '',
+        'missing protocolVersion': valid()..remove('protocolVersion'),
+        'unsupported protocolVersion': valid()..['protocolVersion'] = 2,
+        'missing status': valid()..remove('status'),
+        'empty status': valid()..['status'] = '',
+        'missing connectionMode': valid()..remove('connectionMode'),
+        'tunnel connectionMode': valid()..['connectionMode'] = 'tunnel',
+        'lan connectionMode': valid()..['connectionMode'] = 'lan',
+        'unsupported connectionMode': valid()..['connectionMode'] = 'bluetooth',
+        'missing signedOffer': valid()..remove('signedOffer'),
+        'null signedOffer': valid()..['signedOffer'] = null,
+        'signedOffer with answer type': valid()
+          ..['signedOffer'] = (_readFixture('valid_signal_envelope.json')
+            ..['type'] = 'answer'),
+        'empty acceptedByDeviceId': valid()..['acceptedByDeviceId'] = '',
+        'signedAnswer with offer type': valid()
+          ..['signedAnswer'] = _readFixture('valid_signal_envelope.json'),
+        'non-bool resumeAvailable': valid()..['resumeAvailable'] = 'true',
+        'negative lastSequence': valid()..['lastSequence'] = -1,
+        'string lastSequence': valid()..['lastSequence'] = '0',
+        'zero maxIdleSeconds': valid()..['maxIdleSeconds'] = 0,
+        'negative maxIdleSeconds': valid()..['maxIdleSeconds'] = -5,
+        'missing expiresAt': valid()..remove('expiresAt'),
+        'invalid expiresAt': valid()..['expiresAt'] = 'not-a-date',
+        'timezone-less expiresAt': valid()
+          ..['expiresAt'] = '2026-08-17T12:00:00',
+        'missing lastHeartbeatAt': valid()..remove('lastHeartbeatAt'),
+        'timezone-less lastHeartbeatAt': valid()
+          ..['lastHeartbeatAt'] = '2026-08-17T11:55:00',
+      };
+
+      for (final entry in invalidCases.entries) {
+        expect(
+          () => MobileRemoteSession.fromJson(entry.value),
+          throwsFormatException,
+          reason: 'Case "${entry.key}" should throw FormatException',
+        );
+      }
+    });
+
+    test('rejects missing signedOffer fixture', () {
+      final json = _readFixture('invalid_session_missing_signed_offer.json');
+      expect(() => MobileRemoteSession.fromJson(json), throwsFormatException);
+    });
+  });
+
+  group('MobileTurnCredential', () {
+    test('parses valid TURN credential fixture correctly', () {
+      final json = _readFixture('valid_turn_credential.json');
+      final credential = MobileTurnCredential.fromJson(json);
+
+      expect(credential.urls.length, 2);
+      expect(credential.urls[0], 'turn:turn.example.invalid:3478');
+      expect(credential.urls[1], 'turns:turn.example.invalid:5349');
+      expect(credential.username, 'synthetic-turn-user');
+      expect(credential.credential, 'synthetic-turn-credential');
+      expect(credential.expiresAt, DateTime.parse('2026-08-17T12:00:00.000Z'));
+    });
+
+    test('strict validation rejects invalid TURN credential fields', () {
+      Map<String, dynamic> valid() =>
+          _readFixture('valid_turn_credential.json');
+
+      final invalidCases = <String, Map<String, dynamic>>{
+        'missing urls': valid()..remove('urls'),
+        'non-list urls': valid()..['urls'] = 'turn:turn.example.invalid:3478',
+        'empty urls list': valid()..['urls'] = <dynamic>[],
+        'non-string url item': valid()..['urls'] = <dynamic>[123],
+        'empty string url item': valid()..['urls'] = <dynamic>[''],
+        'missing username': valid()..remove('username'),
+        'empty username': valid()..['username'] = '',
+        'missing credential': valid()..remove('credential'),
+        'empty credential': valid()..['credential'] = '',
+        'missing expiresAt': valid()..remove('expiresAt'),
+        'invalid expiresAt': valid()..['expiresAt'] = 'not-a-date',
+        'timezone-less expiresAt': valid()
+          ..['expiresAt'] = '2026-08-17T12:00:00',
+      };
+
+      for (final entry in invalidCases.entries) {
+        expect(
+          () => MobileTurnCredential.fromJson(entry.value),
+          throwsFormatException,
+          reason: 'Case "${entry.key}" should throw FormatException',
+        );
+      }
+    });
+
+    test('rejects invalid expiry fixture', () {
+      final json = _readFixture('invalid_turn_credential_expiry.json');
+      expect(() => MobileTurnCredential.fromJson(json), throwsFormatException);
+    });
+  });
+
+  group('Deterministic timestamps and timezone handling', () {
+    test('parses explicit UTC (Z) and offset timestamps deterministically', () {
+      final jsonUtc = _readFixture('valid_turn_credential.json')
+        ..['expiresAt'] = '2026-08-17T12:00:00.000Z';
+      final credUtc = MobileTurnCredential.fromJson(jsonUtc);
+      expect(credUtc.expiresAt.toUtc(), DateTime.utc(2026, 8, 17, 12, 0, 0));
+
+      final jsonOffset = _readFixture('valid_turn_credential.json')
+        ..['expiresAt'] = '2026-08-17T15:00:00+03:00';
+      final credOffset = MobileTurnCredential.fromJson(jsonOffset);
+      expect(credOffset.expiresAt.toUtc(), DateTime.utc(2026, 8, 17, 12, 0, 0));
+    });
+  });
+}


### PR DESCRIPTION
## Görev

**MOB-RC-02 — Remote model parsing fixture testleri**

Bu PR, mobil Remote Control modellerindeki sessiz JSON parse fallback’lerini kaldırır, strict validation uygular ve yeniden kullanılabilir sentetik fixture’larla model sözleşmesini test eder.

## Önceki durum

Sprint başlangıcında:

- `mobile_remote_models.dart` satır kapsamı: yaklaşık **%1,8**
- Remote modeller için odaklı fixture testleri bulunmuyordu.
- Eksik veya geçersiz alanlar güvenli olmayan varsayılan değerlere dönüşebiliyordu:
  - Geçersiz tarihler → `DateTime.now()`
  - Eksik protocol sürümü → `1`
  - Eksik sequence → `0`
  - Eksik idle süresi → `90`
  - Eksik string alanları → `""`
  - Eksik listeler → `[]`
  - Eksik boolean değerler → `false`
- Boş SDP payload geçerli kabul edilebiliyordu.
- Desteklenmeyen transport değerleri bağlantı öncesinde açık şekilde reddedilmiyordu.

## Yapılan değişiklikler

### Production modeli

Güncellenen dosya:

`mobile/lib/remote/mobile_remote_models.dart`

Aşağıdaki modeller için strict parsing uygulandı:

1. `MobileRemoteProtocol`
2. `MobileRemoteSession`
3. `MobileSignalEnvelope`
4. `MobileTurnCredential`

Eksik, yanlış tipte, boş veya desteklenmeyen zorunlu alanlar artık açık `FormatException` üretmektedir.

## Model sözleşmeleri

### MobileRemoteProtocol

- `version`: Zorunlu `int`; yalnızca `1`
- `backendCarriesPayload`: Zorunlu `bool`; yalnızca `false`
- `eventTypes`: Zorunlu ve boş olmayan `List<String>`

`backendCarriesPayload: true`, P2P data-plane güvenlik sözleşmesini ihlal ettiği için reddedilir.

### MobileRemoteSession

- `id`, `desktopDeviceId`, `status`: Zorunlu ve boş olmayan string
- `protocolVersion`: Zorunlu `int`; yalnızca `1`
- `connectionMode`: Mobil uygulamada yalnızca `webrtc`
- `signedOffer`: Zorunlu ve `type == "offer"`
- `signedAnswer`: İsteğe bağlı; mevcutsa `type == "answer"`
- `acceptedByDeviceId`: İsteğe bağlı; mevcutsa boş olmayan string
- `resumeAvailable`: İsteğe bağlı boolean; varsayılan `false`
- `lastSequence`: Zorunlu, negatif olmayan `int`
- `maxIdleSeconds`: Zorunlu, pozitif `int`
- `expiresAt`, `lastHeartbeatAt`: Açık timezone içeren geçerli ISO-8601 tarih

### MobileSignalEnvelope

- `version`: Zorunlu `int`; yalnızca `1`
- `sessionProtocolVersion`: Zorunlu `int`; yalnızca `1`
- `type`: Yalnızca `offer` veya `answer`
- `transport`: Mobil uygulamada yalnızca `webrtc`
- `payload`: Zorunlu, boş olmayan SDP/payload string
- `signingKeyFingerprint`: Zorunlu, boş olmayan string
- `signature`: Zorunlu, boş olmayan string

### MobileTurnCredential

- `urls`: Zorunlu ve boş olmayan `List<String>`
- `username`: Zorunlu ve boş olmayan string
- `credential`: Zorunlu ve boş olmayan string
- `expiresAt`: Açık timezone içeren geçerli ISO-8601 tarih

TURN URI scheme doğrulaması native WebRTC katmanına bırakılmıştır; model katmanında yapay URL regex’i eklenmemiştir.

## Fixture dosyaları

`mobile/test/fixtures/remote/` altında sekiz sentetik JSON fixture oluşturuldu:

1. `valid_protocol.json`
2. `invalid_protocol_unsupported.json`
3. `valid_signal_envelope.json`
4. `invalid_signal_envelope_empty_payload.json`
5. `valid_session.json`
6. `invalid_session_missing_signed_offer.json`
7. `valid_turn_credential.json`
8. `invalid_turn_credential_expiry.json`

Fixture’larda gerçek token, API key, secret, kullanıcı hesabı, cihaz kimliği veya TURN parolası bulunmamaktadır.

## Eklenen testler

Yeni test dosyası:

`mobile/test/remote/mobile_remote_models_test.dart`

- Test dosyası: **218 satır**
- Test declaration sayısı: **15**
- Skip edilen test: **0**
- Table-driven alt senaryo sayısı: **70**

Kapsanan davranışlar:

- Geçerli protocol fixture parsing
- Desteklenmeyen protocol sürümü
- P2P güvenlik kuralını ihlal eden `backendCarriesPayload: true`
- Eksik ve yanlış tipte protocol alanları
- Geçerli signal envelope parsing ve `toJson()` round-trip
- Eksik veya desteklenmeyen signal version/type
- Eksik veya desteklenmeyen transport
- Boş ve whitespace-only SDP payload
- Geçerli session parsing
- Optional session alanları
- Eksik `signedOffer`
- Offer/answer type uyuşmazlıkları
- Geçersiz sequence ve idle değerleri
- Geçersiz session tarihleri
- Geçerli TURN credential parsing
- Geçersiz TURN expiry
- Boş veya yanlış tipte TURN alanları
- UTC ve offset içeren tarihlerin deterministik parsing davranışı
- Timezone içermeyen tarihlerin reddedilmesi

## Öncesi ve sonrası

| Kontrol | Önce | Sonra |
|---|---:|---:|
| RC-02 odaklı test | 0 | 15 |
| Sentetik Remote fixture | 0 | 8 |
| Model satır kapsamı | Sprint başlangıcı: %1,8 | %100 |
| Sessiz tarih fallback | Mevcuttu | Kaldırıldı |
| Strict protocol validation | Yoktu | Eklendi |
| Strict transport validation | Yoktu | Eklendi |
| Eksik signedOffer testi | Yoktu | Eklendi |
| Boş SDP testi | Yoktu | Eklendi |
| Yerel toplam test | 85 | 100 |
| Statik analiz | 0 sorun | 0 sorun |

> Toplam test sayısı, RC-02 branch’inin oluşturulduğu base durumunda yerel olarak ölçülmüştür. Güncel base branch ile çalışan PR CI sonucu ayrıca esas alınacaktır.

## Test kanıtları

### RC-02 odaklı testler

```text
flutter test test/remote/mobile_remote_models_test.dart --reporter expanded
00:00 +15: All tests passed!
```

Sonuç: **15/15 test başarılı.**

### Tüm yerel test paketi

```text
flutter test
00:02 +100: All tests passed!
```

Sonuç: **100/100 test başarılı.**

### Statik analiz

```text
flutter analyze
No issues found! (ran in 11.4s)
```

Sonuç: **0 hata, 0 uyarı.**

### Coverage

```text
flutter test --coverage
```

`mobile_remote_models.dart`:

- Lines Found: 101
- Lines Hit: 101
- Satır kapsamı: **%100**
- Kabul kriteri: En az **%85**

## Kabul kriterleri

- [x] Her Remote model için geçerli JSON fixture oluşturuldu.
- [x] Her Remote model için en az bir başarısız parse fixture oluşturuldu.
- [x] Zorunlu alanlar ve alan tipleri test edildi.
- [x] Desteklenmeyen protocol sürümleri reddediliyor.
- [x] Desteklenmeyen mobil transport değerleri bağlantı öncesinde reddediliyor.
- [x] `backendCarriesPayload: true` reddediliyor.
- [x] Geçersiz tarihler `DateTime.now()` değerine çevrilmiyor.
- [x] Eksik `signedOffer` reddediliyor.
- [x] Boş veya whitespace-only SDP payload reddediliyor.
- [x] Offer/answer type ilişkileri doğrulanıyor.
- [x] Fixture’lar RC-05 runtime testlerinde yeniden kullanılabilir.
- [x] Fixture’larda gerçek secret veya cihaz kimliği bulunmuyor.
- [x] `mobile_remote_models.dart` satır kapsamı en az %85: **%100**
- [x] Odaklı testler başarılı: **15/15**
- [x] Tüm yerel testler başarılı: **100/100**
- [x] `flutter analyze` sıfır sorunla tamamlandı.
- [x] Test dosyası 500 satırın altında: **218 satır**

## Riskler ve kapsam dışı konular

- Mobil uygulamada şu anda yalnızca WebRTC transport implementation bulunduğu için `tunnel` ve `lan` reddedilmektedir.
- İleride mobil tunnel/LAN desteği eklenirse kabul edilen transport listesi ilgili implementation ile birlikte genişletilmelidir.
- `signature` ve `signingKeyFingerprint` alanları yapısal olarak doğrulanmaktadır.
- Gerçek kriptografik signature verification bu ticket kapsamında değildir.
- TURN URI scheme doğrulaması native WebRTC katmanına bırakılmıştır.

## Değiştirilen dosyalar

Bu PR toplam 10 RC-02 dosyası içermelidir:

- `mobile/lib/remote/mobile_remote_models.dart`
- `mobile/test/remote/mobile_remote_models_test.dart`
- `mobile/test/fixtures/remote/` altındaki 8 JSON fixture
