### PR TITLE
MOB-RC-03: Add controllable fake remote transport

### DIFF
--- a/mobile/test/remote/mobile_remote_transport_contract_test.dart
+++ b/mobile/test/remote/mobile_remote_transport_contract_test.dart
@@ -1,0 +1,497 @@
+import 'dart:convert';
+
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:aurict_mobile/remote/mobile_device_identity.dart';
+import 'package:aurict_mobile/remote/mobile_remote_event_codec.dart';
+import 'package:aurict_mobile/remote/mobile_remote_models.dart';
+import '../support/fake_mobile_remote_transport.dart';
+import '../support/remote_event_fixtures.dart';
+
+void main() {
+  MobileRemoteSession testSession({String id = 'session-test-001'}) =>
+      MobileRemoteSession(
+        id: id,
+        desktopDeviceId: 'device-test-desktop-001',
+        protocolVersion: 1,
+        status: 'available',
+        connectionMode: 'webrtc',
+        signedOffer: const MobileSignalEnvelope(
+          version: 1,
+          sessionProtocolVersion: 1,
+          type: 'offer',
+          transport: 'webrtc',
+          payload: '{"sdp":"synthetic-offer-sdp"}',
+          signingKeyFingerprint: 'fp-test-desktop',
+          signature: 'sig-test-desktop',
+        ),
+        lastSequence: 0,
+        maxIdleSeconds: 90,
+        expiresAt: DateTime.parse('2026-08-17T12:00:00.000Z'),
+        lastHeartbeatAt: DateTime.parse('2026-08-17T10:00:00.000Z'),
+      );
+
+  MobileDeviceIdentity testIdentity({String fp = 'fp-test-mobile-001'}) =>
+      MobileDeviceIdentity(
+        deviceId: 'device-test-mobile-001',
+        signingPublicKey: 'pk-test-signing',
+        signingKeyFingerprint: fp,
+        encryptionPublicKey: 'pk-test-enc',
+        verified: true,
+      );
+
+  void checkQueues(
+    FakeMobileRemoteTransport t,
+    List<String> c,
+    List<String> o,
+    List<String> d,
+    List<String> f,
+  ) => expect(
+    [t.sendCalls, t.pendingOutbox, t.deliveredMessages, t.flushedMessages],
+    [c, o, d, f],
+  );
+
+  group('FakeMobileRemoteTransport initial state', () {
+    test(
+      'starts with closed state, inactive channel, and empty collections',
+      () {
+        final t = FakeMobileRemoteTransport();
+        expect([t.isChannelOpen, t.isClosed], [isFalse, isFalse]);
+        expect([t.openHandlerCount, t.messageHandlerCount], [0, 0]);
+        expect(
+          [t.openHandlerRegistrationCount, t.messageHandlerRegistrationCount],
+          [0, 0],
+        );
+        expect(
+          [t.duplicateOpenBindingCount, t.duplicateMessageBindingCount],
+          [0, 0],
+        );
+        expect([t.closeCount, t.buildAnswerCallCount], [0, 0]);
+        expect(
+          [t.capturedBuildAnswerCalls.isEmpty, t.lastBuildAnswerCall == null],
+          [isTrue, isTrue],
+        );
+        checkQueues(t, [], [], [], []);
+        expect(t.emittedIncomingMessages, isEmpty);
+      },
+    );
+  });
+
+  group('Channel open lifecycle & handlers', () {
+    test(
+      'simulateChannelOpen and simulateChannelClose update channel state without closing transport',
+      () {
+        final t = FakeMobileRemoteTransport();
+        final order = <int>[];
+        t.onChannelOpen(() => order.add(1));
+        t.onChannelOpen(() => order.add(2));
+        expect([t.isChannelOpen, t.isClosed], [isFalse, isFalse]);
+
+        t.simulateChannelOpen();
+        expect([t.isChannelOpen, t.isClosed], [isTrue, isFalse]);
+        expect(order, [1, 2]);
+
+        t.simulateChannelClose();
+        expect(
+          [t.isChannelOpen, t.isClosed, t.closeCount],
+          [isFalse, isFalse, 0],
+        );
+        expect(
+          [
+            t.openHandlerCount,
+            t.pendingOutbox.length,
+            t.deliveredMessages.length,
+          ],
+          [2, 0, 0],
+        );
+
+        t.simulateChannelOpen();
+        expect([t.isChannelOpen, t.isClosed], [isTrue, isFalse]);
+        expect(order, [1, 2, 1, 2]);
+      },
+    );
+  });
+
+  group('Send & Outbox queue behavior', () {
+    test('send while closed appends to pendingOutbox without delivery', () {
+      final t = FakeMobileRemoteTransport();
+      t.send('payload-A');
+      checkQueues(t, ['payload-A'], ['payload-A'], [], []);
+    });
+
+    test('simulateChannelOpen flushes pending queue in strict FIFO order', () {
+      final t = FakeMobileRemoteTransport();
+      t.send('msg-1');
+      t.send('msg-2');
+      t.send('msg-3');
+      checkQueues(
+        t,
+        ['msg-1', 'msg-2', 'msg-3'],
+        ['msg-1', 'msg-2', 'msg-3'],
+        [],
+        [],
+      );
+
+      t.simulateChannelOpen();
+      checkQueues(
+        t,
+        ['msg-1', 'msg-2', 'msg-3'],
+        [],
+        ['msg-1', 'msg-2', 'msg-3'],
+        ['msg-1', 'msg-2', 'msg-3'],
+      );
+    });
+
+    test(
+      'open handler sees empty pendingOutbox and populated deliveredMessages',
+      () {
+        final t = FakeMobileRemoteTransport();
+        t.send('queued-before-open');
+        var outboxAtCb = -1, deliveredAtCb = -1;
+
+        t.onChannelOpen(() {
+          outboxAtCb = t.pendingOutbox.length;
+          deliveredAtCb = t.deliveredMessages.length;
+        });
+
+        t.simulateChannelOpen();
+        expect([outboxAtCb, deliveredAtCb], [0, 1]);
+        expect(t.deliveredMessages, ['queued-before-open']);
+      },
+    );
+
+    test(
+      'send while open records to deliveredMessages immediately and preserves order',
+      () {
+        final t = FakeMobileRemoteTransport();
+        t.send('A');
+        checkQueues(t, ['A'], ['A'], [], []);
+
+        t.simulateChannelOpen();
+        checkQueues(t, ['A'], [], ['A'], ['A']);
+
+        t.send('B');
+        checkQueues(t, ['A', 'B'], [], ['A', 'B'], ['A']);
+      },
+    );
+  });
+
+  group('Incoming message handling', () {
+    test(
+      'emitIncomingMessage delivers unmodified payload sequentially to handlers',
+      () {
+        final t = FakeMobileRemoteTransport();
+        final log = <String>[];
+        t.onMessage((data) => log.add('h1:$data'));
+        t.onMessage((data) => log.add('h2:$data'));
+
+        const testPayload = '{"kind":"test.incoming","data":123}';
+        t.emitIncomingMessage(testPayload);
+
+        expect(t.emittedIncomingMessages, [testPayload]);
+        expect(log, ['h1:$testPayload', 'h2:$testPayload']);
+      },
+    );
+
+    test('emitIncomingMessage with no registered handlers is a safe no-op', () {
+      final t = FakeMobileRemoteTransport();
+      expect(() => t.emitIncomingMessage('unhandled'), returnsNormally);
+      expect(t.emittedIncomingMessages, ['unhandled']);
+    });
+
+    test(
+      'emitIncomingMessage propagates handler exception without swallowing',
+      () {
+        final t = FakeMobileRemoteTransport();
+        t.onMessage((data) => throw FormatException('Malformed: $data'));
+        expect(() => t.emitIncomingMessage('bad-data'), throwsFormatException);
+      },
+    );
+  });
+
+  group('buildAnswer contract & capture', () {
+    test(
+      'buildAnswer captures arguments, calls signPayload and returns valid envelope',
+      () async {
+        final t = FakeMobileRemoteTransport();
+        final session = testSession();
+        final identity = testIdentity();
+        final turn = MobileTurnCredential(
+          urls: const ['turn:test.turn.org:3478'],
+          username: 'usr-test',
+          credential: 'cred-test',
+          expiresAt: DateTime.parse('2026-08-17T12:00:00.000Z'),
+        );
+
+        var signCalled = false;
+        final envelope = await t.buildAnswer(
+          session: session,
+          identity: identity,
+          signPayload: (payload) async {
+            signCalled = true;
+            return 'sig($payload)';
+          },
+          turnCredential: turn,
+        );
+
+        expect(t.buildAnswerCallCount, 1);
+        expect(t.capturedBuildAnswerCalls, hasLength(1));
+        expect(t.lastBuildAnswerCall?.session.id, session.id);
+        expect(t.lastBuildAnswerCall?.identity.deviceId, identity.deviceId);
+        expect(t.lastBuildAnswerCall?.turnCredential?.username, 'usr-test');
+        expect(signCalled, isTrue);
+        expect(envelope.type, 'answer');
+        expect(envelope.sessionProtocolVersion, session.protocolVersion);
+        expect(envelope.signingKeyFingerprint, identity.signingKeyFingerprint);
+        expect(envelope.signature, startsWith('sig('));
+      },
+    );
+
+    test(
+      'buildAnswer returns configured answerToReturn when provided',
+      () async {
+        const customEnvelope = MobileSignalEnvelope(
+          version: 1,
+          sessionProtocolVersion: 1,
+          type: 'answer',
+          transport: 'webrtc',
+          payload: '{"sdp":"custom-answer-sdp"}',
+          signingKeyFingerprint: 'fp-custom',
+          signature: 'sig-custom',
+        );
+
+        final t = FakeMobileRemoteTransport(answerToReturn: customEnvelope);
+        final result = await t.buildAnswer(
+          session: testSession(),
+          identity: testIdentity(),
+          signPayload: (payload) async => 'ignored',
+        );
+
+        expect(result, same(customEnvelope));
+        expect(result.payload, '{"sdp":"custom-answer-sdp"}');
+      },
+    );
+
+    test(
+      'buildAnswer default path generates synthetic payload and captures calls on error',
+      () async {
+        final t = FakeMobileRemoteTransport();
+        final session = testSession(id: 'session-answer-test');
+        final identity = testIdentity(fp: 'fp-answer-test');
+
+        String? signedPayloadReceived;
+        final envelope = await t.buildAnswer(
+          session: session,
+          identity: identity,
+          signPayload: (payload) async {
+            signedPayloadReceived = payload;
+            return 'signed-test-sha256-hash';
+          },
+        );
+
+        final decoded =
+            jsonDecode(signedPayloadReceived!) as Map<String, dynamic>;
+        expect(decoded['sessionId'], 'session-answer-test');
+        expect(envelope.signature, 'signed-test-sha256-hash');
+
+        final errorTransport = FakeMobileRemoteTransport(
+          buildAnswerError: StateError('failure'),
+        );
+        expect(
+          () => errorTransport.buildAnswer(
+            session: session,
+            identity: identity,
+            signPayload: (p) async => 'sig',
+          ),
+          throwsStateError,
+        );
+        expect(errorTransport.buildAnswerCallCount, 1);
+      },
+    );
+  });
+
+  group('Error injection & ordering', () {
+    test(
+      'send records to sendCalls before throwing sendError leaving queues untouched',
+      () {
+        final t = FakeMobileRemoteTransport(
+          sendError: StateError('Synthetic send failure'),
+        );
+        expect(() => t.send('failed-msg'), throwsStateError);
+        checkQueues(t, ['failed-msg'], [], [], []);
+      },
+    );
+
+    test('close increments closeCount before throwing closeError', () async {
+      final t = FakeMobileRemoteTransport(
+        closeError: StateError('Synthetic close failure'),
+      );
+      t.simulateChannelOpen();
+      expect(t.isChannelOpen, isTrue);
+
+      await expectLater(() => t.close(), throwsStateError);
+      expect([t.closeCount, t.isClosed, t.isChannelOpen], [1, isFalse, isTrue]);
+    });
+  });
+
+  group('Close behavior & idempotence', () {
+    test(
+      'close sets isClosed, disables channel, and is safe on repeated calls',
+      () async {
+        final t = FakeMobileRemoteTransport();
+        t.simulateChannelOpen();
+
+        await t.close();
+        expect(
+          [t.isClosed, t.isChannelOpen, t.closeCount],
+          [isTrue, isFalse, 1],
+        );
+
+        await t.close();
+        await t.close();
+        expect(
+          [t.isClosed, t.isChannelOpen, t.closeCount],
+          [isTrue, isFalse, 3],
+        );
+      },
+    );
+
+    test(
+      'close preserves pendingOutbox and handlers, send-after-close queues to pendingOutbox',
+      () async {
+        final t = FakeMobileRemoteTransport();
+        t.send('unflushed-msg');
+        var openInvoked = false;
+        t.onChannelOpen(() => openInvoked = true);
+
+        await t.close();
+        expect(
+          [t.pendingOutbox, t.openHandlerCount, openInvoked],
+          [
+            ['unflushed-msg'],
+            1,
+            isFalse,
+          ],
+        );
+
+        t.send('after-close-msg');
+        checkQueues(
+          t,
+          ['unflushed-msg', 'after-close-msg'],
+          ['unflushed-msg', 'after-close-msg'],
+          [],
+          [],
+        );
+      },
+    );
+  });
+
+  group('Callback registration & duplicate guard', () {
+    test(
+      'registration counters track totals and duplicates beyond the first',
+      () {
+        final t = FakeMobileRemoteTransport();
+        t.onChannelOpen(() {});
+        t.onChannelOpen(() {});
+        t.onMessage((_) {});
+        t.onMessage((_) {});
+        t.onMessage((_) {});
+
+        expect(
+          [t.openHandlerRegistrationCount, t.messageHandlerRegistrationCount],
+          [2, 3],
+        );
+        expect(
+          [t.duplicateOpenBindingCount, t.duplicateMessageBindingCount],
+          [1, 2],
+        );
+        expect([t.openHandlerCount, t.messageHandlerCount], [2, 3]);
+      },
+    );
+
+    test(
+      'throwOnMultipleBindings throws StateError on multiple registrations without adding handler',
+      () {
+        final t = FakeMobileRemoteTransport(throwOnMultipleBindings: true);
+        var open1 = false, open2 = false;
+        t.onChannelOpen(() => open1 = true);
+        expect(() => t.onChannelOpen(() => open2 = true), throwsStateError);
+        expect(
+          [
+            t.openHandlerRegistrationCount,
+            t.duplicateOpenBindingCount,
+            t.openHandlerCount,
+          ],
+          [2, 1, 1],
+        );
+        t.simulateChannelOpen();
+        expect([open1, open2], [isTrue, isFalse]);
+
+        final msgs = <String>[];
+        t.onMessage((d) => msgs.add('first:$d'));
+        expect(
+          () => t.onMessage((d) => msgs.add('second:$d')),
+          throwsStateError,
+        );
+        expect(
+          [
+            t.messageHandlerRegistrationCount,
+            t.duplicateMessageBindingCount,
+            t.messageHandlerCount,
+          ],
+          [2, 1, 1],
+        );
+        t.emitIncomingMessage('test');
+        expect(msgs, ['first:test']);
+      },
+    );
+  });
+
+  group('RC-01 event fixtures integration', () {
+    test(
+      'remote_event_fixtures produces valid JSON and decodes with MobileRemoteEvent.fromJson',
+      () {
+        final json = createTestRemoteEventJson(
+          sessionId: 'session-contract-test',
+          seq: 5,
+          type: MobileRemoteEventTypes.terminalOutput,
+          payload: {'data': 'stdout line\n', 'stream': 'stdout'},
+        );
+
+        final parsed = MobileRemoteEvent.fromJson(json);
+        expect(parsed.sessionId, 'session-contract-test');
+        expect(parsed.seq, 5);
+        expect(parsed.type, MobileRemoteEventTypes.terminalOutput);
+        expect(parsed.payload['stream'], 'stdout');
+        expect(parsed.signature, syntheticTestSignature);
+      },
+    );
+
+    test(
+      'emitIncomingMessage dispatches synthetic RC-01 raw event string and decodes accurately',
+      () {
+        final t = FakeMobileRemoteTransport();
+        MobileRemoteEvent? decoded;
+
+        t.onMessage(
+          (raw) => decoded = MobileRemoteEvent.fromJson(
+            jsonDecode(raw) as Map<String, dynamic>,
+          ),
+        );
+
+        final rawEvent = createTestRemoteEventRawString(
+          sessionId: 'session-live-001',
+          seq: 1,
+          type: MobileRemoteEventTypes.promptSubmit,
+          payload: {'prompt': 'synthetic test prompt'},
+        );
+
+        t.emitIncomingMessage(rawEvent);
+        expect(decoded?.sessionId, 'session-live-001');
+        expect(decoded?.seq, 1);
+        expect(decoded?.type, MobileRemoteEventTypes.promptSubmit);
+        expect(decoded?.payload['prompt'], 'synthetic test prompt');
+      },
+    );
+  });
+}

--- a/mobile/test/support/fake_mobile_remote_transport.dart
+++ b/mobile/test/support/fake_mobile_remote_transport.dart
@@ -1,0 +1,232 @@
+import 'dart:async';
+import 'dart:convert';
+
+import 'package:aurict_mobile/remote/mobile_device_identity.dart';
+import 'package:aurict_mobile/remote/mobile_remote_models.dart';
+import 'package:aurict_mobile/remote/mobile_remote_transport.dart';
+
+/// Captures arguments passed to a `MobileRemoteTransport.buildAnswer()` call.
+class CapturedBuildAnswerCall {
+  const CapturedBuildAnswerCall({
+    required this.session,
+    required this.identity,
+    required this.signPayload,
+    this.turnCredential,
+  });
+
+  final MobileRemoteSession session;
+  final MobileDeviceIdentity identity;
+  final Future<String> Function(String payload) signPayload;
+  final MobileTurnCredential? turnCredential;
+}
+
+/// Controllable, test-only fake implementation of [MobileRemoteTransport].
+///
+/// Designed to test remote runtime behaviors without real WebRTC, native plugins,
+/// or network connections.
+class FakeMobileRemoteTransport implements MobileRemoteTransport {
+  FakeMobileRemoteTransport({
+    this.throwOnMultipleBindings = false,
+    this.answerToReturn,
+    this.buildAnswerError,
+    this.sendError,
+    this.closeError,
+  });
+
+  /// When true, attempting to register more than one handler for onChannelOpen or
+  /// onMessage throws a [StateError].
+  final bool throwOnMultipleBindings;
+
+  /// Custom answer envelope to return from [buildAnswer]. If null, a deterministic
+  /// synthetic envelope is generated and signed with the provided signPayload.
+  MobileSignalEnvelope? answerToReturn;
+
+  /// Controlled error thrown by [buildAnswer] after capturing the call.
+  Object? buildAnswerError;
+
+  /// Controlled error thrown by [send] after recording to [sendCalls].
+  Object? sendError;
+
+  /// Controlled error thrown by [close] after incrementing [closeCount].
+  Object? closeError;
+
+  bool _isChannelOpen = false;
+  bool _isClosed = false;
+
+  int _openHandlerRegistrationCount = 0;
+  int _messageHandlerRegistrationCount = 0;
+  int _closeCount = 0;
+  int _buildAnswerCallCount = 0;
+
+  final List<void Function()> _openHandlers = [];
+  final List<void Function(String data)> _messageHandlers = [];
+
+  final List<CapturedBuildAnswerCall> _capturedBuildAnswerCalls = [];
+  final List<String> _sendCalls = [];
+  final List<String> _pendingOutbox = [];
+  final List<String> _deliveredMessages = [];
+  final List<String> _flushedMessages = [];
+  final List<String> _emittedIncomingMessages = [];
+
+  bool get isChannelOpen => _isChannelOpen;
+  bool get isClosed => _isClosed;
+
+  int get openHandlerRegistrationCount => _openHandlerRegistrationCount;
+  int get messageHandlerRegistrationCount => _messageHandlerRegistrationCount;
+  int get duplicateOpenBindingCount =>
+      _openHandlerRegistrationCount > 1 ? _openHandlerRegistrationCount - 1 : 0;
+  int get duplicateMessageBindingCount => _messageHandlerRegistrationCount > 1
+      ? _messageHandlerRegistrationCount - 1
+      : 0;
+
+  int get openHandlerCount => _openHandlers.length;
+  int get messageHandlerCount => _messageHandlers.length;
+
+  int get closeCount => _closeCount;
+  int get buildAnswerCallCount => _buildAnswerCallCount;
+
+  List<CapturedBuildAnswerCall> get capturedBuildAnswerCalls =>
+      List.unmodifiable(_capturedBuildAnswerCalls);
+  CapturedBuildAnswerCall? get lastBuildAnswerCall =>
+      _capturedBuildAnswerCalls.isEmpty ? null : _capturedBuildAnswerCalls.last;
+
+  List<String> get sendCalls => List.unmodifiable(_sendCalls);
+  List<String> get pendingOutbox => List.unmodifiable(_pendingOutbox);
+  List<String> get deliveredMessages => List.unmodifiable(_deliveredMessages);
+  List<String> get flushedMessages => List.unmodifiable(_flushedMessages);
+  List<String> get emittedIncomingMessages =>
+      List.unmodifiable(_emittedIncomingMessages);
+
+  @override
+  void onChannelOpen(void Function() handler) {
+    _openHandlerRegistrationCount++;
+    if (throwOnMultipleBindings && _openHandlerRegistrationCount > 1) {
+      throw StateError(
+        'Multiple onChannelOpen bindings detected (attempted registration #$_openHandlerRegistrationCount)',
+      );
+    }
+    _openHandlers.add(handler);
+  }
+
+  @override
+  void onMessage(void Function(String data) handler) {
+    _messageHandlerRegistrationCount++;
+    if (throwOnMultipleBindings && _messageHandlerRegistrationCount > 1) {
+      throw StateError(
+        'Multiple onMessage bindings detected (attempted registration #$_messageHandlerRegistrationCount)',
+      );
+    }
+    _messageHandlers.add(handler);
+  }
+
+  @override
+  void send(String data) {
+    _sendCalls.add(data);
+    if (sendError != null) {
+      throw sendError!;
+    }
+    if (_isChannelOpen) {
+      _deliveredMessages.add(data);
+    } else {
+      _pendingOutbox.add(data);
+    }
+  }
+
+  @override
+  Future<MobileSignalEnvelope> buildAnswer({
+    required MobileRemoteSession session,
+    required MobileDeviceIdentity identity,
+    required Future<String> Function(String payload) signPayload,
+    MobileTurnCredential? turnCredential,
+  }) async {
+    _buildAnswerCallCount++;
+    final call = CapturedBuildAnswerCall(
+      session: session,
+      identity: identity,
+      signPayload: signPayload,
+      turnCredential: turnCredential,
+    );
+    _capturedBuildAnswerCalls.add(call);
+
+    if (buildAnswerError != null) {
+      throw buildAnswerError!;
+    }
+
+    if (answerToReturn != null) {
+      return answerToReturn!;
+    }
+
+    final syntheticPayload = jsonEncode({
+      'kind': 'aurict.mobile.remote.synthetic-answer',
+      'sessionId': session.id,
+      'desktopDeviceId': session.desktopDeviceId,
+      'connectionMode': session.connectionMode,
+      'createdAt': '2026-08-17T10:00:00.000Z',
+      'turn': turnCredential == null
+          ? null
+          : {
+              'urls': turnCredential.urls,
+              'expiresAt': turnCredential.expiresAt.toUtc().toIso8601String(),
+            },
+    });
+
+    final signature = await signPayload(syntheticPayload);
+
+    return MobileSignalEnvelope(
+      version: 1,
+      sessionProtocolVersion: session.protocolVersion,
+      type: 'answer',
+      transport: session.connectionMode,
+      payload: syntheticPayload,
+      signingKeyFingerprint: identity.signingKeyFingerprint,
+      signature: signature,
+    );
+  }
+
+  @override
+  Future<void> close() async {
+    _closeCount++;
+    if (closeError != null) {
+      throw closeError!;
+    }
+    _isClosed = true;
+    _isChannelOpen = false;
+  }
+
+  /// Simulates data channel open event.
+  ///
+  /// Execution sequence matches production `WebRtcMobileTransport._wireChannel`:
+  /// 1. Sets [isChannelOpen] to true.
+  /// 2. Takes a snapshot of [pendingOutbox].
+  /// 3. Clears [pendingOutbox].
+  /// 4. Flushes queued payloads in FIFO order into [flushedMessages] and [deliveredMessages].
+  /// 5. Invokes registered open handlers.
+  void simulateChannelOpen() {
+    _isChannelOpen = true;
+    final queued = List<String>.from(_pendingOutbox);
+    _pendingOutbox.clear();
+    for (final raw in queued) {
+      _flushedMessages.add(raw);
+      _deliveredMessages.add(raw);
+    }
+    for (final handler in _openHandlers) {
+      handler();
+    }
+  }
+
+  /// Simulates closing the channel without running [close].
+  void simulateChannelClose() {
+    _isChannelOpen = false;
+  }
+
+  /// Injects an incoming raw string message into the transport.
+  ///
+  /// Records payload in [emittedIncomingMessages] and sequentially delivers to
+  /// all registered message handlers. If no handlers are registered, this is a safe no-op.
+  void emitIncomingMessage(String data) {
+    _emittedIncomingMessages.add(data);
+    for (final handler in _messageHandlers) {
+      handler(data);
+    }
+  }
+}

--- a/mobile/test/support/remote_event_fixtures.dart
+++ b/mobile/test/support/remote_event_fixtures.dart
@@ -1,0 +1,81 @@
+import 'dart:convert';
+
+import 'package:aurict_mobile/remote/mobile_remote_event_codec.dart';
+
+const syntheticTestSessionId = 'session-test-001';
+const syntheticTestDeviceId = 'device-test-mobile-001';
+const syntheticTestSignature = 'synthetic-test-signature';
+final syntheticTestTimestampUtc = DateTime.parse('2026-08-17T10:00:00.000Z');
+
+/// Creates a synthetic, contract-compliant [MobileRemoteEvent] for testing.
+///
+/// Uses fixed UTC timestamps and explicit synthetic values compliant with the
+/// MOB-RC-01 event contract.
+MobileRemoteEvent createTestRemoteEvent({
+  String sessionId = syntheticTestSessionId,
+  int seq = 1,
+  DateTime? timestamp,
+  String senderDeviceId = syntheticTestDeviceId,
+  String type = MobileRemoteEventTypes.promptSubmit,
+  Map<String, Object?> payload = const {'prompt': 'synthetic test prompt'},
+  String signature = syntheticTestSignature,
+}) {
+  return MobileRemoteEvent(
+    sessionId: sessionId,
+    seq: seq,
+    timestamp: timestamp ?? syntheticTestTimestampUtc,
+    senderDeviceId: senderDeviceId,
+    type: type,
+    payload: payload,
+    signature: signature,
+  );
+}
+
+/// Returns the serialized JSON map of a synthetic [MobileRemoteEvent].
+///
+/// Derived directly from [createTestRemoteEvent] to ensure single-source-of-truth.
+Map<String, Object?> createTestRemoteEventJson({
+  String sessionId = syntheticTestSessionId,
+  int seq = 1,
+  DateTime? timestamp,
+  String senderDeviceId = syntheticTestDeviceId,
+  String type = MobileRemoteEventTypes.promptSubmit,
+  Map<String, Object?> payload = const {'prompt': 'synthetic test prompt'},
+  String signature = syntheticTestSignature,
+}) {
+  return createTestRemoteEvent(
+    sessionId: sessionId,
+    seq: seq,
+    timestamp: timestamp,
+    senderDeviceId: senderDeviceId,
+    type: type,
+    payload: payload,
+    signature: signature,
+  ).toJson();
+}
+
+/// Returns the raw JSON encoded string of a synthetic [MobileRemoteEvent].
+///
+/// Derived directly from [createTestRemoteEventJson]. Suitable for incoming
+/// transport simulation in [FakeMobileRemoteTransport.emitIncomingMessage].
+String createTestRemoteEventRawString({
+  String sessionId = syntheticTestSessionId,
+  int seq = 1,
+  DateTime? timestamp,
+  String senderDeviceId = syntheticTestDeviceId,
+  String type = MobileRemoteEventTypes.promptSubmit,
+  Map<String, Object?> payload = const {'prompt': 'synthetic test prompt'},
+  String signature = syntheticTestSignature,
+}) {
+  return jsonEncode(
+    createTestRemoteEventJson(
+      sessionId: sessionId,
+      seq: seq,
+      timestamp: timestamp,
+      senderDeviceId: senderDeviceId,
+      type: type,
+      payload: payload,
+      signature: signature,
+    ),
+  );
+}


### PR DESCRIPTION
## Görev

**MOB-RC-03 — Test edilebilir Fake Remote Transport altyapısı**

Bu PR, gerçek cihaz, backend, WebRTC peer veya native plugin gerektirmeden `MobileRemoteRuntime` gönderme/alma davranışlarının deterministik şekilde test edilebilmesi için test-only bir `FakeMobileRemoteTransport` sağlar.

Fake transport yalnızca `mobile/test/` altında bulunur. Production kodu veya API’si değiştirilmemiştir.

## Önceki durum

- Runtime testleri gerçek WebRTC transport davranışına bağımlıydı.
- Kanal açılma olayı test tarafından deterministik şekilde tetiklenemiyordu.
- Incoming ham event runtime’a kontrollü şekilde enjekte edilemiyordu.
- Gönderilen, kuyruklanan ve gerçekten teslim edilen mesajlar ayrı ayrı gözlemlenemiyordu.
- `buildAnswer`, `send` ve `close` hataları kontrollü şekilde üretilemiyordu.
- Callback’lerin birden fazla kez bağlanması kolayca tespit edilemiyordu.
- RC-05 runtime entegrasyon testleri için tekrar kullanılabilir fake transport bulunmuyordu.

## Oluşturulan dosyalar

### `mobile/test/support/fake_mobile_remote_transport.dart`

`MobileRemoteTransport` sözleşmesini uygulayan kontrol edilebilir fake transport.

Sağladığı davranışlar:

- Kanal açık/kapalı durumu
- Kanal açılma/kapanma simülasyonu
- FIFO pending outbox
- Incoming ham mesaj enjeksiyonu
- Gönderim ve teslimat kayıtları
- `buildAnswer` argument capture
- Deterministik sentetik answer üretimi
- Configurable answer sonucu
- `buildAnswer`, `send` ve `close` hata enjeksiyonu
- Callback registration sayaçları
- Multiple binding guard
- Close sayacı ve idempotent close davranışı

### `mobile/test/support/remote_event_fixtures.dart`

MOB-RC-01 event sözleşmesine uygun sentetik event üreticileri:

- `createTestRemoteEvent`
- `createTestRemoteEventJson`
- `createTestRemoteEventRawString`

Fixture’lar tek temel event builder üzerinden türetilir ve sabit UTC timestamp kullanır.

### `mobile/test/remote/mobile_remote_transport_contract_test.dart`

Fake transport’un queue, lifecycle, callback, hata ve event fixture davranışlarını doğrulayan 20 sözleşme testi.

## Fake Transport API

### State ve sayaçlar

- `isChannelOpen`
- `isClosed`
- `openHandlerRegistrationCount`
- `messageHandlerRegistrationCount`
- `duplicateOpenBindingCount`
- `duplicateMessageBindingCount`
- `openHandlerCount`
- `messageHandlerCount`
- `closeCount`
- `buildAnswerCallCount`

### BuildAnswer capture

- `capturedBuildAnswerCalls`
- `lastBuildAnswerCall`

Capture edilen değerler:

- Session
- Device identity
- `signPayload` callback’i
- TURN credential

### Mesaj kayıtları

- `sendCalls`: Bütün `send(data)` çağrıları
- `pendingOutbox`: Kanal kapalıyken bekleyen mesajlar
- `deliveredMessages`: Kanal üzerinden teslim edilmiş kabul edilen mesajlar
- `flushedMessages`: Kanal açılışında pending queue’dan teslim edilen mesajlar
- `emittedIncomingMessages`: Test tarafından enjekte edilen incoming mesajlar

Bu ayrım, bir mesajın yalnızca `send()` metoduna verilmesiyle gerçekten teslim edilmesini birbirinden ayırır.

## Queue ve channel davranışı

Kanal kapalıyken:

```text
send("A")

sendCalls: ["A"]
pendingOutbox: ["A"]
deliveredMessages: []
```

Kanal açıldığında:

```text
simulateChannelOpen()

pendingOutbox: []
flushedMessages: ["A"]
deliveredMessages: ["A"]
```

Queue, production `WebRtcMobileTransport` davranışına uygun şekilde FIFO sırasıyla boşaltılır. Open handler’lar yalnızca queue flush tamamlandıktan sonra çalıştırılır.

Kanal açıkken gönderilen yeni mesajlar doğrudan `deliveredMessages` listesine eklenir.

`simulateChannelClose()` yalnızca channel state’ini kapatır:

- `isChannelOpen` → `false`
- `isClosed` değişmez
- `closeCount` artmaz
- Queue ve handler kayıtları korunur

## Callback binding koruması

Fake aşağıdaki registration bilgilerini ayrı ayrı takip eder:

- Toplam open handler registration
- Toplam message handler registration
- İlk kayıttan sonraki open binding girişimleri
- İlk kayıttan sonraki message binding girişimleri

`throwOnMultipleBindings: false` olduğunda birden fazla handler production list davranışına uygun şekilde kaydedilir.

`throwOnMultipleBindings: true` olduğunda ilk kayıttan sonraki registration girişimi `StateError` üretir ve reddedilen handler listeye eklenmez.

Bu kontrol yalnızca aynı callback referansını değil, yeni closure ile yapılan ikinci binding girişimlerini de yakalar.

## Hata enjeksiyonu

### Send hatası

- Çağrı önce `sendCalls` listesine kaydedilir.
- Configured `sendError` yukarıya fırlatılır.
- Pending ve delivered listeleri değiştirilmez.

### BuildAnswer hatası

- Çağrı sayısı ve argument capture kaydedilir.
- Configured `buildAnswerError` yukarıya fırlatılır.

### Close hatası

- `closeCount` artırılır.
- Configured `closeError` yukarıya fırlatılır.
- Başarısız close işleminde channel/closed state değiştirilmez.

Hiçbir hata sessizce yutulmaz.

## Close davranışı

Production transport sözleşmesine uygun olarak:

- Her `close()` çağrısı sayılır.
- Başarılı close sonrası `isClosed = true`
- Başarılı close sonrası `isChannelOpen = false`
- Tekrarlanan close çağrıları güvenlidir.
- Handler ve pending queue kendiliğinden silinmez.
- Close sonrasındaki send çağrısı kapalı kanal davranışıyla pending queue’ya alınır.

## Öncesi ve sonrası

| Kontrol | Önce | Sonra |
|---|---:|---:|
| Fake Remote Transport | Yok | Eklendi |
| RC-03 odaklı test | 0 | 20 |
| Toplam mobil test | 128 | 148 |
| Channel open simülasyonu | Yok | Var |
| Channel close simülasyonu | Yok | Var |
| FIFO outbox testi | Yok | Var |
| Incoming event enjeksiyonu | Yok | Var |
| BuildAnswer capture | Yok | Var |
| Kontrollü hata enjeksiyonu | Yok | Var |
| Duplicate callback guard | Yok | Var |
| Production kod değişikliği | - | Yok |
| Statik analiz sorunu | 0 | 0 |

## Test kanıtları

### Odaklı sözleşme testleri

```text
flutter test test/remote/mobile_remote_transport_contract_test.dart --reporter expanded
00:00 +20: All tests passed!
```

Sonuç:

- 20/20 test başarılı
- 0 başarısız
- 0 skip

### Tüm mobil test paketi

```text
flutter test
00:02 +148: All tests passed!
```

Sonuç:

- 148/148 test başarılı
- 0 başarısız
- 0 skip

### Statik analiz

```text
flutter analyze
No issues found! (ran in 10.1s)
```

Sonuç:

- 0 hata
- 0 uyarı

### Diff kontrolü

```text
git diff --check
```

Sonuç: Whitespace/diff sorunu bulunmadı.

## Dosya sınırları

| Dosya | Satır sayısı | 500 satır sınırı |
|---|---:|---|
| `fake_mobile_remote_transport.dart` | 233 | Geçti |
| `remote_event_fixtures.dart` | 82 | Geçti |
| `mobile_remote_transport_contract_test.dart` | 498 | Geçti |

## Kabul kriterleri

- [x] Test-only `MobileRemoteTransport` fake oluşturuldu.
- [x] Fake yalnızca `mobile/test/` altında tutuldu.
- [x] Production API test amacıyla değiştirilmedi.
- [x] Kanal kapalıyken gönderim queue davranışı simüle ediliyor.
- [x] Kanal açıldığında pending mesajlar FIFO sırasıyla teslim ediliyor.
- [x] Kanal açılma olayı test tarafından tetiklenebiliyor.
- [x] Kanal kapanma durumu test tarafından simüle edilebiliyor.
- [x] Incoming ham event runtime callback’ine enjekte edilebiliyor.
- [x] Gönderilen payload sırası assertion’a açık.
- [x] Send çağrıları ve gerçek teslimatlar ayrı takip ediliyor.
- [x] `buildAnswer` başarı ve hata davranışı kontrol edilebiliyor.
- [x] `send` hatası kontrollü şekilde üretilebiliyor.
- [x] `close` hatası kontrollü şekilde üretilebiliyor.
- [x] Transport hataları sessizce yutulmuyor.
- [x] Callback registration sayıları ölçülebiliyor.
- [x] Multiple callback binding guard bulunuyor.
- [x] Close çağrı sayısı ve state davranışı ölçülebiliyor.
- [x] RC-01 uyumlu sentetik event fixture’ları bulunuyor.
- [x] Hülya’nın RC-05 runtime testlerinde doğrudan kullanılabilir.
- [x] Harici test/mock dependency eklenmedi.
- [x] Bütün yeni dosyalar 500 satırın altında.
- [x] Odaklı testler başarılı: 20/20
- [x] Tüm testler başarılı: 148/148
- [x] `flutter analyze` sıfır sorunla tamamlandı.

## Güvenlik

- Fixture’larda gerçek token, API key, secret veya cihaz kimliği kullanılmadı.
- Gerçek backend, WebRTC peer, native plugin veya ağ bağlantısı kullanılmadı.
- Windows Defender tarafından yerel olarak karantinaya alınan `SKILL.md` dosyası bu commit veya PR’a dahil edilmedi.

## Kapsam dışı konular

- `MobileRemoteRuntime` callback entegrasyonu RC-05 kapsamındadır.
- Runtime send/receive/reconnect/expiry davranışları RC-05 kapsamında Fake Remote Transport kullanılarak test edilecektir.
- Gerçek WebRTC platform davranışı bu fake sözleşme testlerinin yerine geçmez; Android/iOS smoke testleri ayrıca yapılmalıdır.

## Değiştirilen dosyalar

Bu PR yalnızca üç test dosyası içermelidir:

- `mobile/test/support/fake_mobile_remote_transport.dart`
- `mobile/test/support/remote_event_fixtures.dart`
- `mobile/test/remote/mobile_remote_transport_contract_test.dart`

## Reviewer

Hülya — Fake API’nin RC-05 runtime testlerinde kullanılabilirliği ve kabul kriterleri üzerinden review bekleniyor.