### PR TITLE
fix(core): lock subagent mutations atomically

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -5,7 +5,7 @@
     "": {
       "name": "aurict",
       "devDependencies": {
-        "@types/bun": "latest",
+        "@types/bun": "1.3.12",
         "drizzle-kit": "^0.29.0",
         "electron-winstaller": "5.4.4",
         "ink-testing-library": "^4.0.0",
@@ -14,7 +14,7 @@
     },
     "apps/desktop": {
       "name": "hoprel",
-      "version": "1.2.20",
+      "version": "1.2.21",
       "dependencies": {
         "@codemirror/autocomplete": "^6.20.3",
         "@codemirror/commands": "^6.8.0",
@@ -92,7 +92,7 @@
     },
     "apps/web": {
       "name": "web",
-      "version": "1.2.20",
+      "version": "1.2.21",
       "dependencies": {
         "lucide-react": "^1.17.0",
         "next": "16.2.7",
@@ -113,27 +113,27 @@
     },
     "packages/aurict": {
       "name": "aurict",
-      "version": "1.2.20",
+      "version": "1.2.21",
       "bin": {
         "aurict": "./bin/aurict",
       },
       "optionalDependencies": {
-        "@aurict/cli-darwin-arm64": "1.2.20",
-        "@aurict/cli-darwin-x64": "1.2.20",
-        "@aurict/cli-linux-arm64": "1.2.20",
-        "@aurict/cli-linux-x64": "1.2.20",
-        "@aurict/cli-win32-x64": "1.2.20",
+        "@aurict/cli-darwin-arm64": "1.2.21",
+        "@aurict/cli-darwin-x64": "1.2.21",
+        "@aurict/cli-linux-arm64": "1.2.21",
+        "@aurict/cli-linux-x64": "1.2.21",
+        "@aurict/cli-win32-x64": "1.2.21",
       },
     },
     "packages/cli": {
       "name": "@aurict/cli",
-      "version": "1.2.20",
+      "version": "1.2.21",
       "bin": {
         "aurict": "./bin/aurict",
       },
       "devDependencies": {
         "@aurict/core": "workspace:*",
-        "@types/bun": "latest",
+        "@types/bun": "1.3.12",
         "@types/node": "^22.10.0",
         "@types/react": "^18.3.0",
         "ink": "^5.2.1",
@@ -145,36 +145,36 @@
         "wrap-ansi": "^9.0.2",
       },
       "optionalDependencies": {
-        "@aurict/cli-darwin-arm64": "1.2.20",
-        "@aurict/cli-darwin-x64": "1.2.20",
-        "@aurict/cli-linux-arm64": "1.2.20",
-        "@aurict/cli-linux-x64": "1.2.20",
-        "@aurict/cli-win32-x64": "1.2.20",
+        "@aurict/cli-darwin-arm64": "1.2.21",
+        "@aurict/cli-darwin-x64": "1.2.21",
+        "@aurict/cli-linux-arm64": "1.2.21",
+        "@aurict/cli-linux-x64": "1.2.21",
+        "@aurict/cli-win32-x64": "1.2.21",
       },
     },
     "packages/cli-darwin-arm64": {
       "name": "@aurict/cli-darwin-arm64",
-      "version": "1.2.20",
+      "version": "1.2.21",
     },
     "packages/cli-darwin-x64": {
       "name": "@aurict/cli-darwin-x64",
-      "version": "1.2.20",
+      "version": "1.2.21",
     },
     "packages/cli-linux-arm64": {
       "name": "@aurict/cli-linux-arm64",
-      "version": "1.2.20",
+      "version": "1.2.21",
     },
     "packages/cli-linux-x64": {
       "name": "@aurict/cli-linux-x64",
-      "version": "1.2.20",
+      "version": "1.2.21",
     },
     "packages/cli-win32-x64": {
       "name": "@aurict/cli-win32-x64",
-      "version": "1.2.20",
+      "version": "1.2.21",
     },
     "packages/core": {
       "name": "@aurict/core",
-      "version": "1.2.20",
+      "version": "1.2.21",
       "dependencies": {
         "@ai-sdk/amazon-bedrock": "^4.0.113",
         "@ai-sdk/anthropic": "^1.1.5",
@@ -193,7 +193,7 @@
         "zod": "^3.24.0",
       },
       "devDependencies": {
-        "@types/bun": "latest",
+        "@types/bun": "1.3.12",
         "@types/node": "^22.10.0",
         "typescript": "^5.8.0",
       },
@@ -918,7 +918,7 @@
 
     "@types/babel__traverse": ["@types/babel__traverse@7.28.0", "", { "dependencies": { "@babel/types": "^7.28.2" } }, "sha512-8PvcXf70gTDZBgt9ptxJ8elBeBjcLOAcOtoO/mPJjtji1+CdGbHgm77om1GrsPxsiE+uXIpNSK64UYaIwQXd4Q=="],
 
-    "@types/bun": ["@types/bun@1.3.14", "", { "dependencies": { "bun-types": "1.3.14" } }, "sha512-h1hFqFVcvAvD9j9K7ZW7vd82aSA+rTdznZa+5bwvCwqSB1jmmfLcbIWhOLx1/+boy/xmjgCs/OMUL8hRJSmnPw=="],
+    "@types/bun": ["@types/bun@1.3.12", "", { "dependencies": { "bun-types": "1.3.12" } }, "sha512-DBv81elK+/VSwXHDlnH3Qduw+KxkTIWi7TXkAeh24zpi5l0B2kUg9Ga3tb4nJaPcOFswflgi/yAvMVBPrxMB+A=="],
 
     "@types/cacheable-request": ["@types/cacheable-request@6.0.3", "", { "dependencies": { "@types/http-cache-semantics": "*", "@types/keyv": "^3.1.4", "@types/node": "*", "@types/responselike": "^1.0.0" } }, "sha512-IQ3EbTzGxIigb1I3qPZc1rWJnH0BmSKv5QYTalEwweFvyBDLSAe24zP0le/hyi7ecGfZVlIVAg4BZqb8WBwKqw=="],
 
@@ -1164,7 +1164,7 @@
 
     "buffer-from": ["buffer-from@1.1.2", "", {}, "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ=="],
 
-    "bun-types": ["bun-types@1.3.14", "", { "dependencies": { "@types/node": "*" } }, "sha512-4N0ig0fEomHt5R0KCFWjovxow98rIoRwKolrYdCcknNwMekCXRnWEUvgu5soYV8QXtVsrUD8B95MBOZGPvr6KQ=="],
+    "bun-types": ["bun-types@1.3.12", "", { "dependencies": { "@types/node": "*" } }, "sha512-HqOLj5PoFajAQciOMRiIZGNoKxDJSr6qigAttOX40vJuSp6DN/CxWp9s3C1Xwm4oH7ybueITwiaOcWXoYVoRkA=="],
 
     "bytes": ["bytes@3.1.2", "", {}, "sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg=="],
 
@@ -2586,7 +2586,7 @@
 
     "bl/readable-stream": ["readable-stream@3.6.2", "", { "dependencies": { "inherits": "^2.0.3", "string_decoder": "^1.1.1", "util-deprecate": "^1.0.1" } }, "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA=="],
 
-    "bun-types/@types/node": ["@types/node@25.9.1", "", { "dependencies": { "undici-types": ">=7.24.0 <7.24.7" } }, "sha512-xfrlY7UD5rMJk3ZVJP8BNzS28J36YJg+xp+LPXV1TdWxr8uMH5A860QNxYDGQe/ylDSgjxE52Q9VnO7p75tJxg=="],
+    "bun-types/@types/node": ["@types/node@25.9.5", "", { "dependencies": { "undici-types": ">=7.24.0 <7.24.7" } }, "sha512-OScDchr2fwuUmWdf4kZ9h7PcJiYDVInhJizG/biAq3cAvqwYktuy/TYGGdZNMtNTFUP7rnb0NU4TUdm82kt4Rg=="],
 
     "cacache/glob": ["glob@8.1.0", "", { "dependencies": { "fs.realpath": "^1.0.0", "inflight": "^1.0.4", "inherits": "2", "minimatch": "^5.0.1", "once": "^1.3.0" } }, "sha512-r8hpEjiQEYlF2QU0df3dS+nxxSIreXQS1qRhMJM0Q5NDdR386C7jb7Hwwod8Fgiuex+k0GFjgft18yvxm5XoCQ=="],
 

--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
     "quality": "bun run check:quality && bun run typecheck && bun run check:version && bun run test"
   },
   "devDependencies": {
-    "@types/bun": "latest",
+    "@types/bun": "1.3.12",
     "drizzle-kit": "^0.29.0",
     "electron-winstaller": "5.4.4",
     "ink-testing-library": "^4.0.0",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -40,7 +40,7 @@
   },
   "devDependencies": {
     "@aurict/core": "workspace:*",
-    "@types/bun": "latest",
+    "@types/bun": "1.3.12",
     "@types/node": "^22.10.0",
     "@types/react": "^18.3.0",
     "ink": "^5.2.1",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -46,7 +46,7 @@
     "zod": "^3.24.0"
   },
   "devDependencies": {
-    "@types/bun": "latest",
+    "@types/bun": "1.3.12",
     "@types/node": "^22.10.0",
     "typescript": "^5.8.0"
   },

--- a/packages/core/src/agent/file-lock.ts
+++ b/packages/core/src/agent/file-lock.ts
@@ -23,9 +23,12 @@ export interface FileLockInfo {
 export interface AcquireLocksResult {
   acquired: boolean
   conflictingPath?: string
+  acquiredPaths?: string[]
 }
 
-const DEFAULT_TTL_MS = 30_000
+export const DEFAULT_FILE_LOCK_TTL_MS = 30_000
+
+type AcquireFileLockResult = "acquired" | "owned" | "locked"
 
 function lockDir(workdir: string): string {
   return join(workdir, ".aurict", "locks")
@@ -58,30 +61,39 @@ export async function acquireFileLock(
   filePath:  string,
   agentId:   string,
   sessionId: string,
-  ttlMs = DEFAULT_TTL_MS,
+  ttlMs = DEFAULT_FILE_LOCK_TTL_MS,
 ): Promise<boolean> {
+  return (await acquireFileLockResult(workdir, filePath, agentId, sessionId, ttlMs)) !== "locked"
+}
+
+async function acquireFileLockResult(
+  workdir: string,
+  filePath: string,
+  agentId: string,
+  sessionId: string,
+  ttlMs: number,
+): Promise<AcquireFileLockResult> {
   const path = lockPathFor(workdir, filePath)
   await mkdir(lockDir(workdir), { recursive: true })
 
   const now = Date.now()
   const info: FileLockInfo = { agentId, sessionId, acquiredAt: now, expiresAt: now + ttlMs }
-
   try {
     await writeFile(path, JSON.stringify(info), { flag: "wx" })
-    return true
+    return "acquired"
   } catch {
     const existing = await readLock(path)
-    if (!existing) return false // okunamadı (silinmiş/bozuk) — güvenli tarafta kal
-    if (existing.agentId === agentId) return true // aynı agent — idempotent
-    if (existing.expiresAt > now) return false // başka agent hâlâ geçerli şekilde sahip
+    if (!existing) return "locked"
+    if (existing.expiresAt > now) {
+      return existing.agentId === agentId && existing.sessionId === sessionId ? "owned" : "locked"
+    }
 
-    // Stale lock — temizle ve bir kez daha dene (sınırsız retry yok, tek deneme yeterli)
     try {
       await unlink(path)
       await writeFile(path, JSON.stringify(info), { flag: "wx" })
-      return true
+      return "acquired"
     } catch {
-      return false
+      return "locked"
     }
   }
 }
@@ -97,33 +109,33 @@ export async function acquireFileLocks(
   filePaths: string[],
   agentId:   string,
   sessionId: string,
-  ttlMs = DEFAULT_TTL_MS,
+  ttlMs = DEFAULT_FILE_LOCK_TTL_MS,
 ): Promise<AcquireLocksResult> {
   const canonicalSortedPaths = [...new Set(filePaths.map((p) => resolve(workdir, p)))].sort()
   const acquiredPaths: string[] = []
 
   try {
     for (const filePath of canonicalSortedPaths) {
-      const ok = await acquireFileLock(workdir, filePath, agentId, sessionId, ttlMs)
-      if (!ok) {
-        await releaseFileLocks(workdir, acquiredPaths, agentId)
+      const lock = await acquireFileLockResult(workdir, filePath, agentId, sessionId, ttlMs)
+      if (lock === "locked") {
+        await releaseFileLocks(workdir, acquiredPaths, agentId, sessionId)
         return { acquired: false, conflictingPath: filePath }
       }
-      acquiredPaths.push(filePath)
+      if (lock === "acquired") acquiredPaths.push(filePath)
     }
   } catch (error) {
-    await releaseFileLocks(workdir, acquiredPaths, agentId)
+    await releaseFileLocks(workdir, acquiredPaths, agentId, sessionId)
     throw error
   }
 
-  return { acquired: true }
+  return { acquired: true, acquiredPaths }
 }
 
 /** Bir lock'u serbest bırakır. Sadece sahibi (aynı agentId) serbest bırakabilir. */
-export async function releaseFileLock(workdir: string, filePath: string, agentId: string): Promise<boolean> {
+export async function releaseFileLock(workdir: string, filePath: string, agentId: string, sessionId?: string): Promise<boolean> {
   const path = lockPathFor(workdir, filePath)
   const existing = await readLock(path)
-  if (!existing || existing.agentId !== agentId) return false
+  if (!existing || existing.agentId !== agentId || (sessionId !== undefined && existing.sessionId !== sessionId)) return false
   try {
     await unlink(path)
     return true
@@ -137,10 +149,11 @@ export async function releaseFileLocks(
   workdir:   string,
   filePaths: string[],
   agentId:   string,
+  sessionId?: string,
 ): Promise<boolean> {
   const canonicalPaths = [...new Set(filePaths.map((p) => resolve(workdir, p)))]
   const results = await Promise.all(
-    canonicalPaths.map((filePath) => releaseFileLock(workdir, filePath, agentId)),
+    canonicalPaths.map((filePath) => releaseFileLock(workdir, filePath, agentId, sessionId)),
   )
   return results.every(Boolean)
 }

--- a/packages/core/src/agent/file-lock.ts
+++ b/packages/core/src/agent/file-lock.ts
@@ -1,5 +1,5 @@
 import { mkdir, readFile, writeFile, unlink } from "node:fs/promises"
-import { join } from "node:path"
+import { join, resolve } from "node:path"
 import { createHash } from "node:crypto"
 
 /**
@@ -20,6 +20,11 @@ export interface FileLockInfo {
   expiresAt:  number
 }
 
+export interface AcquireLocksResult {
+  acquired: boolean
+  conflictingPath?: string
+}
+
 const DEFAULT_TTL_MS = 30_000
 
 function lockDir(workdir: string): string {
@@ -27,7 +32,8 @@ function lockDir(workdir: string): string {
 }
 
 function lockPathFor(workdir: string, filePath: string): string {
-  const hash = createHash("sha1").update(filePath).digest("hex")
+  const canonical = resolve(workdir, filePath)
+  const hash = createHash("sha1").update(canonical).digest("hex")
   return join(lockDir(workdir), `${hash}.lock`)
 }
 
@@ -80,6 +86,39 @@ export async function acquireFileLock(
   }
 }
 
+/**
+ * Birden fazla dosya için deterministik sırada lock almaya çalışır.
+ *   - Yolları normalize eder, yinelenenleri eler ve alfabetik olarak sıralar.
+ *   - Herhangi bir dosyanın lock'u alınamazsa, bu çağrıda şimdiye kadar alınan
+ *     tüm lock'lar geri bırakılır (rollback) ve çakışan yol ile birlikte false döner.
+ */
+export async function acquireFileLocks(
+  workdir:   string,
+  filePaths: string[],
+  agentId:   string,
+  sessionId: string,
+  ttlMs = DEFAULT_TTL_MS,
+): Promise<AcquireLocksResult> {
+  const canonicalSortedPaths = [...new Set(filePaths.map((p) => resolve(workdir, p)))].sort()
+  const acquiredPaths: string[] = []
+
+  try {
+    for (const filePath of canonicalSortedPaths) {
+      const ok = await acquireFileLock(workdir, filePath, agentId, sessionId, ttlMs)
+      if (!ok) {
+        await releaseFileLocks(workdir, acquiredPaths, agentId)
+        return { acquired: false, conflictingPath: filePath }
+      }
+      acquiredPaths.push(filePath)
+    }
+  } catch (error) {
+    await releaseFileLocks(workdir, acquiredPaths, agentId)
+    throw error
+  }
+
+  return { acquired: true }
+}
+
 /** Bir lock'u serbest bırakır. Sadece sahibi (aynı agentId) serbest bırakabilir. */
 export async function releaseFileLock(workdir: string, filePath: string, agentId: string): Promise<boolean> {
   const path = lockPathFor(workdir, filePath)
@@ -91,6 +130,19 @@ export async function releaseFileLock(workdir: string, filePath: string, agentId
   } catch {
     return false
   }
+}
+
+/** Birden fazla lock'u toplu serbest bırakır. */
+export async function releaseFileLocks(
+  workdir:   string,
+  filePaths: string[],
+  agentId:   string,
+): Promise<boolean> {
+  const canonicalPaths = [...new Set(filePaths.map((p) => resolve(workdir, p)))]
+  const results = await Promise.all(
+    canonicalPaths.map((filePath) => releaseFileLock(workdir, filePath, agentId)),
+  )
+  return results.every(Boolean)
 }
 
 /** Bir dosyanın şu an (başka bir agent tarafından, geçerli şekilde) kilitli olup olmadığını döner. */

--- a/packages/core/src/tool/execution-helpers.ts
+++ b/packages/core/src/tool/execution-helpers.ts
@@ -6,7 +6,7 @@ import type { FlightReplayPolicy } from "../diagnostics/flight-recorder.js"
 import type { PatchSummary } from "./built-in/apply-patch.js"
 import type { ToolContext, ToolDef } from "./types.js"
 
-const DEFAULT_TOOL_TIMEOUT_MS = 120_000
+export const DEFAULT_TOOL_TIMEOUT_MS = 120_000
 const PERMISSION_PROMPT_TIMEOUT_MS = 60_000
 const TODO_ACTIONS = new Set(["list", "add", "complete", "delete"])
 

--- a/packages/core/src/tool/executor.ts
+++ b/packages/core/src/tool/executor.ts
@@ -641,10 +641,6 @@ export async function executeTool(
   let verificationBase: Awaited<ReturnType<typeof fingerprintWorkspaceRevision>> | undefined;
 
   try {
-    // --- Faz 6: Progress tracking başlat ---
-    const progressMessage = getToolProgressMessage(def.id, args);
-    progressTracker.start(def.id, progressMessage);
-
     verificationPaths = def.id === "verify"
       ? verificationPathsForSession(ctx, args)
       : [];
@@ -655,6 +651,10 @@ export async function executeTool(
       ctx.workdir,
       toolMutationPaths,
     );
+
+    // --- Faz 6: Progress tracking başlat ---
+    const progressMessage = getToolProgressMessage(def.id, args);
+    progressTracker.start(def.id, progressMessage);
 
     // --- Execute (timeout korumalı + gerçek iptal zinciri) ---
     //

--- a/packages/core/src/tool/executor.ts
+++ b/packages/core/src/tool/executor.ts
@@ -41,7 +41,7 @@ import {
   getWorkingSetSnapshot,
   recordVerificationRevision,
 } from "../agent/working-set.js";
-import { acquireFileLock, releaseFileLock } from "../agent/file-lock.js";
+import { acquireFileLocks, releaseFileLocks } from "../agent/file-lock.js";
 import { recordFailureCooldown } from "../agent/failure-cooldown.js";
 import { failedStrategiesStore } from "../agent/failed-strategies-store.js";
 import { recordRunTrace } from "../agent/run-trace.js";
@@ -609,83 +609,92 @@ export async function executeTool(
   // ana session'da overhead yok. agentPool.spawn her worker'ı AYRI bir Worker
   // thread'de çalıştırdığından (bkz. agent/pool.ts) in-memory bir lock hiçbir
   // çakışmayı önlemez; bu yüzden dosya tabanlı bir lock kullanılıyor.
-  const lockTargetPath =
-    def.id === "edit" || def.id === "write" ? String(args["path"] ?? "") : "";
-  let fileLockAcquired = false;
-  if (ctx.isSubagent && lockTargetPath) {
-    const absLockPath = resolve(ctx.workdir, lockTargetPath);
-    fileLockAcquired = await acquireFileLock(
+  // Workspace transaction mutasyon yolları ile worker lock yolları birebir eşlenir.
+  const toolMutationPaths = mutationPathsForTool(def.id, args);
+  let acquiredLockPaths: string[] = [];
+  if (ctx.isSubagent && toolMutationPaths.length > 0) {
+    const lockResult = await acquireFileLocks(
       ctx.workdir,
-      absLockPath,
+      toolMutationPaths,
       ctx.sessionId,
       ctx.sessionId,
     );
-    if (!fileLockAcquired) {
+    if (!lockResult.acquired) {
+      const rawConflict =
+        toolMutationPaths.find((p) => resolve(ctx.workdir, p) === lockResult.conflictingPath) ??
+        lockResult.conflictingPath ??
+        "a file";
       return {
         output: "",
-        error: `[file-lock] '${lockTargetPath}' is currently being edited by another worker. Wait and retry, or work on a different file.`,
+        error: `[file-lock] '${rawConflict}' is currently being edited by another worker. Wait and retry, or work on a different file.`,
       };
     }
+    acquiredLockPaths = toolMutationPaths;
   }
 
-  // --- Faz 6: Progress tracking başlat ---
-  const progressMessage = getToolProgressMessage(def.id, args);
-  progressTracker.start(def.id, progressMessage);
-
-  // --- Execute (timeout korumalı + gerçek iptal zinciri) ---
-  //
-  // execAC: bu tool çağrısına özel AbortController.
-  //   • ctx.signal (loop'tan gelen opts.signal) abort edilirse → execAC da abort edilir.
-  //   • withToolTimeout süresi dolunca → execAC abort edilir.
-  // Tool, ctx.signal yerine execCtx.signal'i kullanır; her iki kaynaktan da iptal alır.
   const execAC = new AbortController();
   const mirrorFn = () => execAC.abort();
-  if (ctx.signal.aborted) {
-    execAC.abort();
-  } else {
-    ctx.signal.addEventListener("abort", mirrorFn, { once: true });
-  }
-  const execCtx: ToolContext = { ...ctx, signal: execAC.signal };
-
   const start = Date.now();
   let result: ExecuteResult;
   let execError: string | null = null;
-  const verificationPaths = def.id === "verify"
-    ? verificationPathsForSession(ctx, args)
-    : [];
-  const verificationBase = verificationPaths.length > 0
-    ? await fingerprintWorkspaceRevision(ctx.workdir, verificationPaths)
-    : undefined;
-  const transaction = await WorkspaceTransaction.begin(
-    ctx.workdir,
-    mutationPathsForTool(def.id, args),
-  );
+  let verificationPaths: string[] = [];
+  let verificationBase: Awaited<ReturnType<typeof fingerprintWorkspaceRevision>> | undefined;
 
   try {
-    result = await withToolTimeout(def.execute(args, execCtx), def, () =>
-      execAC.abort(),
-    );
-  } catch (err) {
-    execError = String(err);
-    result = { output: "", error: execError };
-  } finally {
-    ctx.signal.removeEventListener("abort", mirrorFn);
-    if (fileLockAcquired) {
-      const absLockPath = resolve(ctx.workdir, lockTargetPath);
-      observeBackground(releaseFileLock(ctx.workdir, absLockPath, ctx.sessionId), `file lock release for ${absLockPath}`);
-    }
-  }
+    // --- Faz 6: Progress tracking başlat ---
+    const progressMessage = getToolProgressMessage(def.id, args);
+    progressTracker.start(def.id, progressMessage);
 
-  if (transaction) {
-    const committed = await transaction.commit();
-    const transactionRecord = result.error ? await transaction.rollback() : committed;
-    result = {
-      ...result,
-      metadata: { ...result.metadata, transaction: transactionRecord },
-      ...(transactionRecord.status === "rollback_conflict"
-        ? { error: `${result.error ?? "Tool failed"}\n[transaction] Rollback refused because the file changed after this tool attempt.` }
-        : {}),
-    };
+    verificationPaths = def.id === "verify"
+      ? verificationPathsForSession(ctx, args)
+      : [];
+    verificationBase = verificationPaths.length > 0
+      ? await fingerprintWorkspaceRevision(ctx.workdir, verificationPaths)
+      : undefined;
+    const transaction = await WorkspaceTransaction.begin(
+      ctx.workdir,
+      toolMutationPaths,
+    );
+
+    // --- Execute (timeout korumalı + gerçek iptal zinciri) ---
+    //
+    // execAC: bu tool çağrısına özel AbortController.
+    //   • ctx.signal (loop'tan gelen opts.signal) abort edilirse → execAC da abort edilir.
+    //   • withToolTimeout süresi dolunca → execAC abort edilir.
+    // Tool, ctx.signal yerine execCtx.signal'i kullanır; her iki kaynaktan da iptal alır.
+    if (ctx.signal.aborted) {
+      execAC.abort();
+    } else {
+      ctx.signal.addEventListener("abort", mirrorFn, { once: true });
+    }
+    const execCtx: ToolContext = { ...ctx, signal: execAC.signal };
+
+    try {
+      result = await withToolTimeout(def.execute(args, execCtx), def, () =>
+        execAC.abort(),
+      );
+    } catch (err) {
+      execError = String(err);
+      result = { output: "", error: execError };
+    } finally {
+      ctx.signal.removeEventListener("abort", mirrorFn);
+    }
+
+    if (transaction) {
+      const committed = await transaction.commit();
+      const transactionRecord = result.error ? await transaction.rollback() : committed;
+      result = {
+        ...result,
+        metadata: { ...result.metadata, transaction: transactionRecord },
+        ...(transactionRecord.status === "rollback_conflict"
+          ? { error: `${result.error ?? "Tool failed"}\n[transaction] Rollback refused because the file changed after this tool attempt.` }
+          : {}),
+      };
+    }
+  } finally {
+    if (acquiredLockPaths.length > 0) {
+      await releaseFileLocks(ctx.workdir, acquiredLockPaths, ctx.sessionId);
+    }
   }
 
   if (!result.error && importPrecheckWarning) {

--- a/packages/core/src/tool/executor.ts
+++ b/packages/core/src/tool/executor.ts
@@ -41,7 +41,7 @@ import {
   getWorkingSetSnapshot,
   recordVerificationRevision,
 } from "../agent/working-set.js";
-import { acquireFileLocks, releaseFileLocks } from "../agent/file-lock.js";
+import { acquireFileLocks, DEFAULT_FILE_LOCK_TTL_MS, releaseFileLocks } from "../agent/file-lock.js";
 import { recordFailureCooldown } from "../agent/failure-cooldown.js";
 import { failedStrategiesStore } from "../agent/failed-strategies-store.js";
 import { recordRunTrace } from "../agent/run-trace.js";
@@ -63,6 +63,7 @@ import {
   patchPermissionMetadata,
   verifyLocalImports,
   waitForPermission,
+  DEFAULT_TOOL_TIMEOUT_MS,
   withTimeout,
   withToolTimeout,
 } from "./execution-helpers.js";
@@ -618,6 +619,7 @@ export async function executeTool(
       toolMutationPaths,
       ctx.sessionId,
       ctx.sessionId,
+      (def.timeoutMs ?? DEFAULT_TOOL_TIMEOUT_MS) + DEFAULT_FILE_LOCK_TTL_MS,
     );
     if (!lockResult.acquired) {
       const rawConflict =
@@ -629,7 +631,7 @@ export async function executeTool(
         error: `[file-lock] '${rawConflict}' is currently being edited by another worker. Wait and retry, or work on a different file.`,
       };
     }
-    acquiredLockPaths = toolMutationPaths;
+    acquiredLockPaths = lockResult.acquiredPaths ?? [];
   }
 
   const execAC = new AbortController();
@@ -693,7 +695,7 @@ export async function executeTool(
     }
   } finally {
     if (acquiredLockPaths.length > 0) {
-      await releaseFileLocks(ctx.workdir, acquiredLockPaths, ctx.sessionId);
+      await releaseFileLocks(ctx.workdir, acquiredLockPaths, ctx.sessionId, ctx.sessionId);
     }
   }
 

--- a/packages/core/test/file-lock.test.ts
+++ b/packages/core/test/file-lock.test.ts
@@ -85,6 +85,23 @@ describe("agent/file-lock.ts — saf modül davranışı", () => {
     expect(releasedByOwner).toBe(true)
   })
 
+  it("releaseFileLock same agent's other session lock cannot release", async () => {
+    const f = target()
+    await acquireFileLock(dir, f, "agent-a", "session-a")
+    expect(await releaseFileLock(dir, f, "agent-a", "session-b")).toBe(false)
+    expect(await releaseFileLock(dir, f, "agent-a", "session-a")).toBe(true)
+  })
+
+  it("expired lock is reacquired by same worker instead of treated as owned", async () => {
+    const f = target()
+    await acquireFileLock(dir, f, "agent-a", "session-a", 10)
+    await new Promise((resolve) => setTimeout(resolve, 30))
+
+    expect(await acquireFileLock(dir, f, "agent-a", "session-a", 200)).toBe(true)
+    expect((await getFileLockInfo(dir, f))!.expiresAt).toBeGreaterThan(Date.now() + 150)
+    await releaseFileLock(dir, f, "agent-a", "session-a")
+  })
+
   it("release sonrası başka bir agent lock alabilir", async () => {
     const f = target()
     await acquireFileLock(dir, f, "agent-a", "session-a")
@@ -136,6 +153,20 @@ describe("agent/file-lock.ts — saf modül davranışı", () => {
     // Başka bir worker f1'i hemen kilitleyebilmeli
     const ok = await acquireFileLock(dir, f1, "third-agent", "third-session")
     expect(ok).toBe(true)
+  })
+
+  it("acquireFileLocks rollback keeps locks it did not create", async () => {
+    const f1 = target()
+    const f2 = target()
+    await acquireFileLock(dir, f1, "agent-batch", "session-batch")
+    await acquireFileLock(dir, f2, "other-agent", "other-session")
+
+    const result = await acquireFileLocks(dir, [f1, f2], "agent-batch", "session-batch")
+    expect(result.acquired).toBe(false)
+    expect((await getFileLockInfo(dir, f1))?.agentId).toBe("agent-batch")
+
+    await releaseFileLock(dir, f1, "agent-batch", "session-batch")
+    await releaseFileLock(dir, f2, "other-agent", "other-session")
   })
 
   it("acquireFileLocks yinelenen ve göreceli yolları tek bir kilide indirger (deduplicate/canonicalize)", async () => {

--- a/packages/core/test/file-lock.test.ts
+++ b/packages/core/test/file-lock.test.ts
@@ -22,6 +22,7 @@ import { writeTool } from "../src/tool/built-in/write.js"
 import { editTool } from "../src/tool/built-in/edit.js"
 import { applyPatchTool } from "../src/tool/built-in/apply-patch.js"
 import { notebookEditTool } from "../src/tool/built-in/notebook.js"
+import { progressTracker } from "../src/util/progress.js"
 
 let dir: string
 
@@ -467,8 +468,10 @@ describe("tool/executor.ts — Faz 3C entegrasyonu & çok dosyalı subagent muta
   })
 
   it("transaction kurulumu başarısız olsa bile kilit serbest bırakılır", async () => {
+    progressTracker.clear()
     const result = executeTool(writeTool, { path: dir, content: "new" }, ctx({ sessionId: "worker-transaction" }))
     await expect(result).rejects.toThrow()
     expect(await getFileLockInfo(dir, dir)).toBeNull()
+    expect(progressTracker.getActiveTools()).toEqual([])
   })
 })

--- a/packages/core/test/file-lock.test.ts
+++ b/packages/core/test/file-lock.test.ts
@@ -7,7 +7,7 @@
  *     - solo session (isSubagent: false) kilit kontrolünden etkilenmez.
  */
 import { describe, it, expect, beforeAll, afterAll, afterEach } from "bun:test"
-import { existsSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs"
+import { mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs"
 import { tmpdir } from "node:os"
 import { join } from "node:path"
 import {

--- a/packages/core/test/file-lock.test.ts
+++ b/packages/core/test/file-lock.test.ts
@@ -1,20 +1,27 @@
 /**
  * Faz 3C — dosya tabanlı worker lock.
- *  1) agent/file-lock.ts'in saf modül testleri (acquire/release/stale/idempotent).
- *  2) tool/executor.ts entegrasyonu: isSubagent:true iken kilitli bir dosyaya
- *     yazma denemesi engellenir; isSubagent:false (solo session) hiç etkilenmez.
+ *  1) agent/file-lock.ts saf modül testleri (acquire/release/stale/idempotent/batch/rollback/ordering).
+ *  2) tool/executor.ts entegrasyonu:
+ *     - subagent mutasyonları (write, edit, apply_patch, notebook_edit) worker file lock ile korunur.
+ *     - çok dosyalı apply_patch tüm kilitleri önceden alır; kısmi kilit başarısızlığında geri bırakır.
+ *     - solo session (isSubagent: false) kilit kontrolünden etkilenmez.
  */
 import { describe, it, expect, beforeAll, afterAll, afterEach } from "bun:test"
-import { mkdtempSync, rmSync } from "node:fs"
+import { existsSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs"
 import { tmpdir } from "node:os"
 import { join } from "node:path"
 import {
   acquireFileLock,
+  acquireFileLocks,
   releaseFileLock,
+  releaseFileLocks,
   getFileLockInfo,
 } from "../src/agent/file-lock.js"
 import { executeTool, ExecutorEvents, PermissionGate, PermissionStore } from "../src/index.js"
 import { writeTool } from "../src/tool/built-in/write.js"
+import { editTool } from "../src/tool/built-in/edit.js"
+import { applyPatchTool } from "../src/tool/built-in/apply-patch.js"
+import { notebookEditTool } from "../src/tool/built-in/notebook.js"
 
 let dir: string
 
@@ -99,19 +106,84 @@ describe("agent/file-lock.ts — saf modül davranışı", () => {
     const info = await getFileLockInfo(dir, target())
     expect(info).toBeNull()
   })
+
+  it("acquireFileLocks birden fazla dosya için başarıyla lock alır", async () => {
+    const f1 = target()
+    const f2 = target()
+    const result = await acquireFileLocks(dir, [f1, f2], "agent-batch", "session-batch")
+    expect(result.acquired).toBe(true)
+    expect(result.conflictingPath).toBeUndefined()
+    expect(await getFileLockInfo(dir, f1)).not.toBeNull()
+    expect(await getFileLockInfo(dir, f2)).not.toBeNull()
+  })
+
+  it("acquireFileLocks bir dosya kilitliyse başarısız olur ve kısmi kilitleri geri bırakır", async () => {
+    const f1 = target()
+    const f2 = target()
+    const f3 = target()
+    // f2 başka bir worker tarafından kilitlenmiş olsun
+    await acquireFileLock(dir, f2, "other-agent", "other-session")
+
+    const result = await acquireFileLocks(dir, [f1, f2, f3], "agent-batch", "session-batch")
+    expect(result.acquired).toBe(false)
+    expect(result.conflictingPath).toBe(f2)
+
+    // f1 ve f3 üzerinde kilit kalmamış olmalı (rollback)
+    expect(await getFileLockInfo(dir, f1)).toBeNull()
+    expect(await getFileLockInfo(dir, f3)).toBeNull()
+
+    // Başka bir worker f1'i hemen kilitleyebilmeli
+    const ok = await acquireFileLock(dir, f1, "third-agent", "third-session")
+    expect(ok).toBe(true)
+  })
+
+  it("acquireFileLocks yinelenen ve göreceli yolları tek bir kilide indirger (deduplicate/canonicalize)", async () => {
+    const rel = `rel-test-${Date.now()}.ts`
+    const abs = join(dir, rel)
+    const result = await acquireFileLocks(dir, [rel, `./${rel}`, abs], "agent-dedup", "session-dedup")
+    expect(result.acquired).toBe(true)
+    const info = await getFileLockInfo(dir, abs)
+    expect(info?.agentId).toBe("agent-dedup")
+    await releaseFileLocks(dir, [rel], "agent-dedup")
+    expect(await getFileLockInfo(dir, abs)).toBeNull()
+  })
+
+  it("acquireFileLocks giriş sırasından bağımsız olarak aynı deterministik sırayı kullanır", async () => {
+    const a = join(dir, "order-a.ts")
+    const b = join(dir, "order-b.ts")
+    await acquireFileLock(dir, a, "other-agent", "other-session")
+    await acquireFileLock(dir, b, "other-agent", "other-session")
+
+    const reversed = await acquireFileLocks(dir, [b, a], "agent-order", "session-order")
+    const ordered = await acquireFileLocks(dir, [a, b], "agent-order", "session-order")
+
+    expect(reversed.conflictingPath).toBe(a)
+    expect(ordered.conflictingPath).toBe(a)
+  })
+
+  it("releaseFileLocks tüm kilitleri toplu serbest bırakır", async () => {
+    const f1 = target()
+    const f2 = target()
+    await acquireFileLocks(dir, [f1, f2], "agent-rel", "session-rel")
+    const released = await releaseFileLocks(dir, [f1, f2], "agent-rel")
+    expect(released).toBe(true)
+    expect(await getFileLockInfo(dir, f1)).toBeNull()
+    expect(await getFileLockInfo(dir, f2)).toBeNull()
+  })
 })
 
-describe("tool/executor.ts — Faz 3C entegrasyonu", () => {
+describe("tool/executor.ts — Faz 3C entegrasyonu & çok dosyalı subagent mutasyon kilitleme", () => {
   afterEach(async () => {
     PermissionStore.clear()
     PermissionGate.cancelPending()
     // Her testten sonra olası kalıntı lock'ları temizle
     try { await releaseFileLock(dir, join(dir, "shared.ts"), "other-worker") } catch { /* ignore */ }
+    try { await releaseFileLock(dir, join(dir, "a.txt"), "other-worker") } catch { /* ignore */ }
+    try { await releaseFileLock(dir, join(dir, "b.txt"), "other-worker") } catch { /* ignore */ }
+    try { await releaseFileLock(dir, join(dir, "c.txt"), "other-worker") } catch { /* ignore */ }
   })
 
-  it("isSubagent:false (solo session) kilitli bir dosyaya yazarken bile lock kontrolünden hiç etkilenmez", async () => {
-    // isSubagent:false → PermissionGate gerçek bir kullanıcı onayı bekler; testte
-    // otomatik onaylayan bir dinleyici kuruyoruz (permission-metadata.test.ts ile aynı desen).
+  it("Test H: isSubagent:false (solo session) kilitli bir dosyaya yazarken bile lock kontrolünden hiç etkilenmez", async () => {
     const off = ExecutorEvents.on((event) => {
       PermissionGate.respond(event.request.id, "allow_once")
     })
@@ -126,7 +198,7 @@ describe("tool/executor.ts — Faz 3C entegrasyonu", () => {
     }
   })
 
-  it("isSubagent:true + dosya başka bir worker tarafından kilitliyse [file-lock] hatasıyla engellenir", async () => {
+  it("Test F: write aracı — isSubagent:true + dosya başka bir worker tarafından kilitliyse [file-lock] hatasıyla engellenir", async () => {
     const f = join(dir, "shared.ts")
     await acquireFileLock(dir, f, "other-worker", "other-session")
     try {
@@ -137,7 +209,7 @@ describe("tool/executor.ts — Faz 3C entegrasyonu", () => {
     }
   })
 
-  it("isSubagent:true + dosya AYNI worker (sessionId) tarafından kilitliyse (idempotent) engellenmez", async () => {
+  it("Test F: write aracı — isSubagent:true + dosya AYNI worker (sessionId) tarafından kilitliyse (idempotent) engellenmez", async () => {
     const f = join(dir, "shared.ts")
     await acquireFileLock(dir, f, "worker-a", "worker-a")
     try {
@@ -148,11 +220,255 @@ describe("tool/executor.ts — Faz 3C entegrasyonu", () => {
     }
   })
 
-  it("başarılı bir write sonrası executeTool kendi lock'unu serbest bırakır (bir sonraki worker engellenmez)", async () => {
+  it("Test F: write aracı — başarılı bir write sonrası executeTool kendi lock'unu serbest bırakır", async () => {
     const f = join(dir, "shared.ts")
     const result = await executeTool(writeTool, { path: f, content: "export const x = 1\n" }, ctx({ sessionId: "worker-a" }))
     expect(result.error).toBeUndefined()
     const info = await getFileLockInfo(dir, f)
     expect(info).toBeNull()
+  })
+
+  it("Test G: edit aracı — kilitli dosyaya düzenleme yapamaz, kendi kilidine izin verir ve işlem bitince kilit serbest kalır", async () => {
+    const f = join(dir, "edit-target.txt")
+    writeFileSync(f, "hello world\n")
+
+    await acquireFileLock(dir, f, "other-worker", "other-session")
+    try {
+      const blocked = await executeTool(editTool, { path: f, old_string: "hello", new_string: "hi" }, ctx({ sessionId: "worker-b" }))
+      expect(blocked.error).toContain("[file-lock]")
+    } finally {
+      await releaseFileLock(dir, f, "other-worker")
+    }
+
+    const success = await executeTool(editTool, { path: f, old_string: "hello", new_string: "hi" }, ctx({ sessionId: "worker-a" }))
+    expect(success.error).toBeUndefined()
+    expect(readFileSync(f, "utf8")).toBe("hi world\n")
+    expect(await getFileLockInfo(dir, f)).toBeNull()
+  })
+
+  it("Test A: apply_patch aracı — kilitli hedef dosyayı içeren patch [file-lock] hatası ile engellenir ve çalıştırılmaz", async () => {
+    const f = join(dir, "a.txt")
+    writeFileSync(f, "initial\n")
+    await acquireFileLock(dir, f, "other-worker", "other-session")
+
+    try {
+      const patchText = `*** Begin Patch
+*** Update File: a.txt
+@@
+-initial
++modified
+*** End Patch`
+      const result = await executeTool(applyPatchTool, { patchText }, ctx({ sessionId: "worker-b" }))
+      expect(result.error).toContain("[file-lock]")
+      expect(readFileSync(f, "utf8")).toBe("initial\n")
+    } finally {
+      await releaseFileLock(dir, f, "other-worker")
+    }
+  })
+
+  it("Test B: apply_patch aracı — çok dosyalı patch'te bir dosya kilitliyse tüm patch reddedilir ve hiçbir dosya değişmez", async () => {
+    const a = join(dir, "a.txt")
+    const b = join(dir, "b.txt")
+    const c = join(dir, "c.txt")
+    writeFileSync(a, "a-init\n")
+    writeFileSync(b, "b-init\n")
+    writeFileSync(c, "c-init\n")
+
+    // b.txt başka bir worker tarafından kilitlensin
+    await acquireFileLock(dir, b, "other-worker", "other-session")
+
+    try {
+      const patchText = `*** Begin Patch
+*** Update File: a.txt
+@@
+-a-init
++a-modified
+*** Update File: b.txt
+@@
+-b-init
++b-modified
+*** Update File: c.txt
+@@
+-c-init
++c-modified
+*** End Patch`
+
+      const result = await executeTool(applyPatchTool, { patchText }, ctx({ sessionId: "worker-b" }))
+      expect(result.error).toContain("[file-lock]")
+
+      // Hiçbir dosya değişmemiş olmalı
+      expect(readFileSync(a, "utf8")).toBe("a-init\n")
+      expect(readFileSync(b, "utf8")).toBe("b-init\n")
+      expect(readFileSync(c, "utf8")).toBe("c-init\n")
+    } finally {
+      await releaseFileLock(dir, b, "other-worker")
+    }
+  })
+
+  it("Test C: kısmi kilit başarısızlığında geri bırakılan dosyaları başka bir worker hemen kilitleyebilir", async () => {
+    const a = join(dir, "a.txt")
+    const b = join(dir, "b.txt")
+    const c = join(dir, "c.txt")
+    writeFileSync(a, "a-init\n")
+    writeFileSync(b, "b-init\n")
+    writeFileSync(c, "c-init\n")
+
+    await acquireFileLock(dir, c, "other-worker", "other-session")
+
+    try {
+      const patchText = `*** Begin Patch
+*** Update File: a.txt
+@@
+-a-init
++a-modified
+*** Update File: b.txt
+@@
+-b-init
++b-modified
+*** Update File: c.txt
+@@
+-c-init
++c-modified
+*** End Patch`
+
+      const result = await executeTool(applyPatchTool, { patchText }, ctx({ sessionId: "worker-attempt" }))
+      expect(result.error).toContain("[file-lock]")
+
+      // a.txt üzerinde worker-attempt'in kilidi kalmamış olmalı
+      expect(await getFileLockInfo(dir, a)).toBeNull()
+      expect(await getFileLockInfo(dir, b)).toBeNull()
+
+      const relock = await acquireFileLocks(dir, [a, b], "worker-c", "worker-c")
+      expect(relock.acquired).toBe(true)
+      await releaseFileLocks(dir, [a, b], "worker-c")
+    } finally {
+      await releaseFileLock(dir, c, "other-worker")
+    }
+  })
+
+  it("Test D: başarılı çok dosyalı apply_patch sonrası tüm kilitler serbest bırakılır", async () => {
+    const a = join(dir, "a.txt")
+    const b = join(dir, "b.txt")
+    const c = join(dir, "c.txt")
+    writeFileSync(a, "a-init\n")
+    writeFileSync(b, "b-init\n")
+    writeFileSync(c, "c-init\n")
+
+    const patchText = `*** Begin Patch
+*** Update File: a.txt
+@@
+-a-init
++a-success
+*** Update File: b.txt
+@@
+-b-init
++b-success
+*** Update File: c.txt
+@@
+-c-init
++c-success
+*** End Patch`
+
+    const result = await executeTool(applyPatchTool, { patchText }, ctx({ sessionId: "worker-multi" }))
+    expect(result.error).toBeUndefined()
+    expect(readFileSync(a, "utf8")).toBe("a-success\n")
+    expect(readFileSync(b, "utf8")).toBe("b-success\n")
+    expect(readFileSync(c, "utf8")).toBe("c-success\n")
+
+    // Tüm kilitler serbest kalmış olmalı
+    expect(await getFileLockInfo(dir, a)).toBeNull()
+    expect(await getFileLockInfo(dir, b)).toBeNull()
+    expect(await getFileLockInfo(dir, c)).toBeNull()
+  })
+
+  it("Test E: bağımsız mutasyonlar birbirini engellemez", async () => {
+    const a = join(dir, "a.txt")
+    const b = join(dir, "b.txt")
+    writeFileSync(a, "a-init\n")
+    writeFileSync(b, "b-init\n")
+
+    // Worker A, a.txt'yi kilitler
+    await acquireFileLock(dir, a, "worker-a", "worker-a")
+
+    try {
+      // Worker B, bağımsız b.txt dosyasına yazabilir
+      const result = await executeTool(writeTool, { path: b, content: "b-from-worker-b\n" }, ctx({ sessionId: "worker-b" }))
+      expect(result.error).toBeUndefined()
+      expect(readFileSync(b, "utf8")).toBe("b-from-worker-b\n")
+    } finally {
+      await releaseFileLock(dir, a, "worker-a")
+    }
+  })
+
+  it("Test I: yinelenen mutasyon yolları tek bir kilit altında başarıyla çalışır", async () => {
+    const a = join(dir, "a.txt")
+    writeFileSync(a, "line 1\nline 2\n")
+
+    const patchText = `*** Begin Patch
+*** Update File: a.txt
+@@
+-line 1
++line 1 mod
+*** End Patch`
+
+    const result = await executeTool(applyPatchTool, { patchText }, ctx({ sessionId: "worker-dedup" }))
+    expect(result.error).toBeUndefined()
+    expect(await getFileLockInfo(dir, a)).toBeNull()
+  })
+
+  it("notebook_edit aracı subagent mutasyon kilitlemesine katılır", async () => {
+    const nbPath = join(dir, "test.ipynb")
+    const initialNb = JSON.stringify({
+      cells: [{ cell_type: "code", source: ["print(1)\n"], metadata: {}, execution_count: null, outputs: [] }],
+      metadata: {},
+      nbformat: 4,
+      nbformat_minor: 5,
+    })
+    writeFileSync(nbPath, initialNb)
+
+    await acquireFileLock(dir, nbPath, "other-worker", "other-session")
+    try {
+      const blocked = await executeTool(
+        notebookEditTool,
+        { path: nbPath, action: "update", cellIndex: 0, source: "print(2)\n" },
+        ctx({ sessionId: "worker-nb" }),
+      )
+      expect(blocked.error).toContain("[file-lock]")
+    } finally {
+      await releaseFileLock(dir, nbPath, "other-worker")
+    }
+
+    const success = await executeTool(
+      notebookEditTool,
+      { path: nbPath, action: "update", cellIndex: 0, source: "print(2)\n" },
+      ctx({ sessionId: "worker-nb" }),
+    )
+    expect(success.error).toBeUndefined()
+    expect(await getFileLockInfo(dir, nbPath)).toBeNull()
+  })
+
+  it("Test K: araç çalışırken throw etse bile kilitler serbest bırakılır", async () => {
+    const f = join(dir, "throw-test.txt")
+    writeFileSync(f, "content\n")
+
+    // Hatalı argüman veya çalışma zamanı hatası simülasyonu
+    const brokenTool = {
+      ...writeTool,
+      async execute() {
+        throw new Error("simulated failure")
+      },
+    }
+
+    const result = await executeTool(brokenTool, { path: f, content: "new" }, ctx({ sessionId: "worker-throw" }))
+    expect(result.error).toContain("simulated failure")
+
+    // Kilit serbest kalmış olmalı
+    expect(await getFileLockInfo(dir, f)).toBeNull()
+  })
+
+  it("transaction kurulumu başarısız olsa bile kilit serbest bırakılır", async () => {
+    const result = executeTool(writeTool, { path: dir, content: "new" }, ctx({ sessionId: "worker-transaction" }))
+    await expect(result).rejects.toThrow()
+    expect(await getFileLockInfo(dir, dir)).toBeNull()
   })
 })

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -12,7 +12,7 @@
     "hono": "^4.7.0"
   },
   "devDependencies": {
-    "@types/bun": "latest",
+    "@types/bun": "1.3.12",
     "typescript": "^5.8.0"
   }
 }


### PR DESCRIPTION
## Summary

Makes subagent file mutations atomic across all affected paths.

Previously, multi-file operations could acquire locks incrementally and leave partial locks behind when a later path conflicted or setup failed. This could block unrelated work and allow inconsistent mutation behavior.

## Changes

- Canonicalize, deduplicate, and deterministically sort mutation paths.
- Acquire all required file locks before executing a mutation.
- Reject the entire operation if any target path is already locked.
- Roll back partial acquisitions when lock acquisition fails or throws.
- Release every acquired lock after:
  - successful execution
  - tool errors
  - thrown exceptions
  - transaction setup failures
- Apply locking to:
  - `write`
  - `edit`
  - `notebook_edit`
  - `apply_patch`
- Keep main-session behavior unchanged; locking only affects subagents.
- Reuse the same mutation-path calculation for locking and transactions.
- Pin `@types/bun` to `1.3.12`, matching the CI Bun runtime.
- Refresh `bun.lock` so frozen CI installs remain reproducible.

## Tests

Added coverage for:

- successful multi-file acquisition
- rollback after partial acquisition
- deterministic lock ordering
- canonical and duplicate paths
- conflicting multi-file patches
- independent mutations
- successful lock cleanup
- cleanup after tool exceptions
- cleanup after transaction setup failure
- notebook mutations
- main-session lock bypass

## Verification

Verified in an isolated Linux container using Bun 1.3.12:

- `bun install --frozen-lockfile`
- `bun run check:quality`
- core TypeScript check
- file-lock integration tests: **27 passed, 0 failed**
- `git diff --check`

## Scope

No public API expansion or new runtime dependency was introduced.
