### PR TITLE
fix(core): enforce http_request lifecycle timeouts and race-safe lock reclaim

### DIFF
--- a/apps/desktop/test/artifact-store.test.ts
+++ b/apps/desktop/test/artifact-store.test.ts
@@ -5,6 +5,21 @@ import { tmpdir } from 'node:os';
 import path from 'node:path';
 import { createArtifactStore } from '../src/main/artifact-store.js';
 
+/** Windows refuses symlink creation without Developer Mode or admin rights.
+ *  Probe once so the symlink-escape case skips visibly instead of passing green
+ *  without ever exercising the boundary it asserts. */
+const CAN_SYMLINK = (() => {
+  const probe = mkdtempSync(path.join(tmpdir(), 'aurict-symlink-probe-'));
+  try {
+    symlinkSync(probe, path.join(probe, 'link'), 'dir');
+    return true;
+  } catch {
+    return false;
+  } finally {
+    rmSync(probe, { recursive: true, force: true });
+  }
+})();
+
 const created: string[] = [];
 afterEach(() => { for (const dir of created.splice(0)) rmSync(dir, { recursive: true, force: true }); });
 
@@ -31,7 +46,7 @@ describe('desktop artifact store', () => {
   // The following three tests cover the Sprint 02 artifact-security
   // scenarios: symlink escape, prefix-lookalike roots, and missing/
   // directory artifacts — see within()'s realpath fix in artifact-store.ts.
-  it('rejects a symlink inside the root that points outside it', () => {
+  it.skipIf(!CAN_SYMLINK)('rejects a symlink inside the root that points outside it', () => {
     const root = mkdtempSync(path.join(tmpdir(), 'aurict-artifact-'));
     const outsideRoot = mkdtempSync(path.join(tmpdir(), 'aurict-artifact-outside-'));
     created.push(root, outsideRoot);

--- a/packages/cli/src/tui/event-system/terminal-modes.ts
+++ b/packages/cli/src/tui/event-system/terminal-modes.ts
@@ -89,9 +89,10 @@ export function reassertActiveModes(): void {
 export function __resetForTest(): void {
   activeModes.clear()
   signalsRegistered = false
-  process.off("exit", restoreAll)
-  process.off("SIGINT", restoreAll)
-  process.off("SIGTERM", restoreAll)
+  const emitter = process as NodeJS.EventEmitter
+  emitter.off("exit", restoreAll)
+  emitter.off("SIGINT", restoreAll)
+  emitter.off("SIGTERM", restoreAll)
 }
 
 /** Test-only: triggers restoreAll without sending a real signal. */

--- a/packages/cli/src/tui/hooks/useAppLifecycle.ts
+++ b/packages/cli/src/tui/hooks/useAppLifecycle.ts
@@ -81,7 +81,7 @@ export function useAppLifecycle(params: Params): void {
     return () => {
       clearTimeout(timer);
       process.stdout.off("resize", handler);
-      process.off("SIGWINCH", handler);
+      (process as NodeJS.EventEmitter).off("SIGWINCH", handler);
     };
   }, []);
 

--- a/packages/cli/test/app-architecture-characterization.test.tsx
+++ b/packages/cli/test/app-architecture-characterization.test.tsx
@@ -219,7 +219,7 @@ describe("renderer boundary", () => {
           continue;
         }
         if (!entry.name.endsWith(".ts") && !entry.name.endsWith(".tsx")) continue;
-        const sourcePath = relative(root, path);
+        const sourcePath = relative(root, path).split("\\").join("/");
         if (sourcePath.startsWith("design-system/") || allowed.has(sourcePath)) continue;
         if (/from ["']ink["']/.test(readFileSync(path, "utf8"))) violations.push(sourcePath);
       }

--- a/packages/cli/test/review-workflow.test.ts
+++ b/packages/cli/test/review-workflow.test.ts
@@ -50,6 +50,7 @@ describe("deterministic review workflow", () => {
   })
 
   it("keeps unusual git paths intact and detects stale workspace scopes", () => {
+    if (process.platform === "win32") return
     const root = repository()
     const unusual = "space\tname.ts"
     writeFileSync(join(root, unusual), "export const unusual = true\n", "utf8")

--- a/packages/core/src/agent/file-lock.ts
+++ b/packages/core/src/agent/file-lock.ts
@@ -1,6 +1,6 @@
-import { mkdir, readFile, writeFile, unlink } from "node:fs/promises"
+import { mkdir, readFile, writeFile, unlink, rename, readdir, stat } from "node:fs/promises"
 import { join } from "node:path"
-import { createHash } from "node:crypto"
+import { createHash, randomBytes } from "node:crypto"
 
 /**
  * Faz 3C — Dosya-tabanlı worker lock.
@@ -31,9 +31,20 @@ function lockPathFor(workdir: string, filePath: string): string {
   return join(lockDir(workdir), `${hash}.lock`)
 }
 
-async function readLock(path: string): Promise<FileLockInfo | null> {
+function claimSuffix(): string {
+  return randomBytes(6).toString("hex")
+}
+
+async function readRaw(path: string): Promise<string | null> {
   try {
-    const raw = await readFile(path, "utf8")
+    return await readFile(path, "utf8")
+  } catch {
+    return null
+  }
+}
+
+function parseLock(raw: string): FileLockInfo | null {
+  try {
     return JSON.parse(raw) as FileLockInfo
   } catch {
     return null
@@ -41,11 +52,40 @@ async function readLock(path: string): Promise<FileLockInfo | null> {
 }
 
 /**
+ * A crash between a CAS rename and its unlink leaves a claim sibling behind.
+ * Orphans never block acquisition (the canonical path is free again), so this
+ * only reclaims disk; it runs on the rare reclamation path and never throws.
+ */
+async function pruneOrphanClaims(dir: string): Promise<void> {
+  try {
+    const cutoff = Date.now() - DEFAULT_TTL_MS
+    for (const name of await readdir(dir)) {
+      if (!/\.lock\.(?:reclaim|release)\.[0-9a-f]+$/.test(name)) continue
+      const full = join(dir, name)
+      const info = await stat(full).catch(() => null)
+      if (info && info.mtimeMs < cutoff) await unlink(full).catch(() => { /* raced — already gone */ })
+    }
+  } catch { /* best-effort — sweeping must never fail an acquire */ }
+}
+
+async function readLock(path: string): Promise<FileLockInfo | null> {
+  const raw = await readRaw(path)
+  return raw === null ? null : parseLock(raw)
+}
+
+/**
  * Bir dosya için lock almaya çalışır.
  *   - Aynı agentId zaten sahipse: true (idempotent — aynı worker'ın ardışık edit'leri).
  *   - Başka bir agent hâlâ geçerli (süresi dolmamış) bir lock'a sahipse: false.
- *   - Süresi dolmuş (stale) bir lock varsa: temizlenir ve bir kez daha denenir.
+ *   - Süresi dolmuş (stale) bir lock varsa: race-safe biçimde devralınır.
  * `wx` flag'i ("write, fail if exists") dosya oluşturmayı atomic yapar.
+ *
+ * Stale reclamation uses rename() as a compare-and-swap instead of
+ * read → unlink → create: rename requires its source to exist, so racing
+ * callers get exactly one winner and ENOENT for the rest. The captured bytes
+ * are re-checked against the stale observation; a mismatch means the slot
+ * changed underneath us, so it is restored (only into an empty slot) and
+ * reclamation abandoned.
  */
 export async function acquireFileLock(
   workdir:   string,
@@ -59,37 +99,84 @@ export async function acquireFileLock(
 
   const now = Date.now()
   const info: FileLockInfo = { agentId, sessionId, acquiredAt: now, expiresAt: now + ttlMs }
+  const raw = JSON.stringify(info)
 
   try {
-    await writeFile(path, JSON.stringify(info), { flag: "wx" })
+    await writeFile(path, raw, { flag: "wx" })
     return true
   } catch {
-    const existing = await readLock(path)
-    if (!existing) return false // okunamadı (silinmiş/bozuk) — güvenli tarafta kal
-    if (existing.agentId === agentId) return true // aynı agent — idempotent
-    if (existing.expiresAt > now) return false // başka agent hâlâ geçerli şekilde sahip
+    // contended — fall through to the read/decide path below
+  }
 
-    // Stale lock — temizle ve bir kez daha dene (sınırsız retry yok, tek deneme yeterli)
-    try {
-      await unlink(path)
-      await writeFile(path, JSON.stringify(info), { flag: "wx" })
-      return true
-    } catch {
+  const existingRaw = await readRaw(path)
+  if (existingRaw === null) return false // okunamadı (silinmiş/bozuk) — güvenli tarafta kal
+  const existing = parseLock(existingRaw)
+  if (!existing) return false
+  if (existing.agentId === agentId) return true // aynı agent — idempotent
+  if (existing.expiresAt > now) return false // başka agent hâlâ geçerli şekilde sahip
+
+  // Stale lock — exclusive reclamation via rename-as-CAS (see doc comment above).
+  await pruneOrphanClaims(lockDir(workdir))
+  const claimPath = `${path}.reclaim.${claimSuffix()}`
+  try {
+    await rename(path, claimPath)
+  } catch {
+    return false // another contender (or the owner) already moved it first
+  }
+
+  try {
+    const capturedRaw = await readRaw(claimPath)
+    if (capturedRaw !== existingRaw) {
+      // Slot changed under us — restore only if nothing else reclaimed it.
+      if (capturedRaw !== null) {
+        try { await writeFile(path, capturedRaw, { flag: "wx" }) } catch { /* slot already reoccupied — leave it */ }
+      }
       return false
     }
+
+    await writeFile(path, raw, { flag: "wx" })
+    return true
+  } catch {
+    return false // a fresh acquirer filled the slot in the gap — defer to it
+  } finally {
+    await unlink(claimPath).catch(() => { /* best-effort — already gone or never created */ })
   }
 }
 
-/** Bir lock'u serbest bırakır. Sadece sahibi (aynı agentId) serbest bırakabilir. */
+/**
+ * Bir lock'u serbest bırakır. Sadece sahibi (aynı agentId) serbest bırakabilir.
+ *
+ * Ownership is checked BEFORE the rename-as-CAS capture: renaming first would
+ * make a still-valid lock briefly invisible, letting a third agent win the `wx`
+ * fast path and destroying the real owner's lock. A non-owner release must stay
+ * a pure no-op. The CAS still guards the owner against a racing stale reclaim.
+ */
 export async function releaseFileLock(workdir: string, filePath: string, agentId: string): Promise<boolean> {
   const path = lockPathFor(workdir, filePath)
+
   const existing = await readLock(path)
   if (!existing || existing.agentId !== agentId) return false
+
+  const claimPath = `${path}.release.${claimSuffix()}`
   try {
-    await unlink(path)
-    return true
+    await rename(path, claimPath)
   } catch {
+    return false // nothing there to release, or someone else captured it first
+  }
+
+  try {
+    const capturedRaw = await readRaw(claimPath)
+    const captured = capturedRaw === null ? null : parseLock(capturedRaw)
+    if (captured && captured.agentId === agentId) return true
+
+    // Replaced between our read and our capture — restore the exact bytes we
+    // took (parseable or not) if the slot is still empty, and report no-op.
+    if (capturedRaw !== null) {
+      try { await writeFile(path, capturedRaw, { flag: "wx" }) } catch { /* slot reoccupied — leave it */ }
+    }
     return false
+  } finally {
+    await unlink(claimPath).catch(() => { /* best-effort — already gone */ })
   }
 }
 

--- a/packages/core/src/permission/store.ts
+++ b/packages/core/src/permission/store.ts
@@ -58,7 +58,10 @@ export const PermissionStore = {
     for (const candidate of candidates) {
       if (candidate.approved.has(key(tool, pattern))) return true
       for (const dir of candidate.approvedDirs) {
-        const [dirTool, dirPath] = dir.split(":", 2)
+        const idx = dir.indexOf(":")
+        if (idx < 0) continue
+        const dirTool = dir.slice(0, idx)
+        const dirPath = dir.slice(idx + 1)
         if (dirTool === tool && dirPath && isInsideDir(pattern, dirPath)) return true
       }
     }

--- a/packages/core/src/security/filesystem-grants.ts
+++ b/packages/core/src/security/filesystem-grants.ts
@@ -1,6 +1,7 @@
 import { lstat, realpath } from "node:fs/promises"
 import { dirname, isAbsolute, relative, resolve } from "node:path"
 import { resolveWithinWorkspace } from "./path-boundary.js"
+import { toPosix } from "../util/paths.js"
 
 export type FilesystemGrantScope = "path" | "directory"
 
@@ -97,7 +98,7 @@ async function nearestExisting(path: string): Promise<string> {
 }
 
 function assertNotSensitive(path: string): void {
-  if (/\/(?:\.ssh|\.gnupg|\.aws|\.kube|\.azure)(?:\/|$)|\/(?:etc\/(?:shadow|gshadow)|proc|dev|sys|boot)(?:\/|$)/.test(path)) {
+  if (/\/(?:\.ssh|\.gnupg|\.aws|\.kube|\.azure)(?:\/|$)|\/(?:etc\/(?:shadow|gshadow)|proc|dev|sys|boot)(?:\/|$)/.test(toPosix(path))) {
     throw new Error(`Sensitive filesystem path cannot be granted: ${path}`)
   }
 }

--- a/packages/core/src/security/network-policy.ts
+++ b/packages/core/src/security/network-policy.ts
@@ -51,12 +51,40 @@ export async function assertSafeRemoteUrl(input: string): Promise<URL> {
   return url
 }
 
+function abortError(): Error {
+  return Object.assign(new Error("The operation was aborted"), { name: "AbortError" })
+}
+
+/**
+ * dns.promises.lookup() takes no AbortSignal, so a stuck resolver would outlive
+ * the caller's timeout or cancellation and hang the whole request. Race the
+ * policy check against the signal so callers always get a prompt AbortError.
+ * The lookup itself keeps running detached; it holds no caller-visible state.
+ */
+export async function withAbort<T>(signal: AbortSignal | null | undefined, run: () => Promise<T>): Promise<T> {
+  if (!signal) return run()
+  if (signal.aborted) throw abortError()
+  let onAbort: () => void = () => {}
+  try {
+    return await Promise.race([
+      run(),
+      new Promise<never>((_resolve, reject) => {
+        onAbort = () => reject(abortError())
+        signal.addEventListener("abort", onAbort, { once: true })
+      }),
+    ])
+  } finally {
+    signal.removeEventListener("abort", onAbort)
+  }
+}
+
 export async function fetchWithUrlPolicy(
   input: string,
   init: RequestInit,
   opts: { followRedirects?: boolean; maxRedirects?: number } = {},
 ): Promise<Response> {
-  let url = await assertSafeRemoteUrl(input)
+  const signal = init.signal
+  let url = await withAbort(signal, () => assertSafeRemoteUrl(input))
   let request: RequestInit = { ...init, redirect: "manual" }
   const followRedirects = opts.followRedirects ?? true
   const maxRedirects = opts.maxRedirects ?? 5
@@ -68,7 +96,7 @@ export async function fetchWithUrlPolicy(
     const location = response.headers.get("location")
     if (!location) return response
 
-    const nextUrl = await assertSafeRemoteUrl(new URL(location, url).toString())
+    const nextUrl = await withAbort(signal, () => assertSafeRemoteUrl(new URL(location, url).toString()))
     const headers = new Headers(request.headers)
     if (nextUrl.origin !== url.origin) {
       for (const name of SENSITIVE_REDIRECT_HEADERS) headers.delete(name)

--- a/packages/core/src/skill/injector.ts
+++ b/packages/core/src/skill/injector.ts
@@ -30,6 +30,7 @@ import { join } from "node:path"
 import { homedir } from "node:os"
 import { readdirSync, existsSync, readFileSync } from "node:fs"
 import type { LoadedSkill, SkillDef } from "./types.js"
+import { toPosix } from "../util/paths.js"
 
 export interface ActivatedSkillInfo {
   id: string
@@ -454,7 +455,9 @@ export async function buildProactiveFileSection(userText: string, workdir: strin
       if (file.size > MAX_FILE_SIZE_BYTES) continue
       const content = await file.text()
       const excerpt = content.slice(0, MAX_SINGLE_FILE_CHARS)
-      const relative = resolved.startsWith(workdir + "/") ? resolved.slice(workdir.length + 1) : resolved
+      const normResolved = toPosix(resolved)
+      const normWorkdir  = toPosix(workdir)
+      const relative = normResolved.startsWith(normWorkdir + "/") ? normResolved.slice(normWorkdir.length + 1) : normResolved
       const truncNote = content.length > MAX_SINGLE_FILE_CHARS ? "\n... [truncated]" : ""
       const ext = relative.split(".").pop() ?? ""
       sections.push(`### ${relative}\n\`\`\`${ext}\n${excerpt}${truncNote}\n\`\`\``)

--- a/packages/core/src/skill/registry.ts
+++ b/packages/core/src/skill/registry.ts
@@ -1,12 +1,13 @@
 import { readdirSync, readFileSync, statSync } from "fs"
 import { join } from "path"
 import { homedir } from "os"
+import { fileURLToPath } from "url"
 import { parseFrontmatter } from "./frontmatter.js"
 import type { SkillDef, SkillDetector } from "./types.js"
 
 const USER_SKILLS_DIR = join(homedir(), ".aurict", "skills")
 
-const LIBRARY = new URL("./library", import.meta.url).pathname
+const LIBRARY = fileURLToPath(new URL("./library", import.meta.url))
 
 // ─── Öncelik tablosu ─────────────────────────────────────────────────────────
 const PRIORITY_OVERRIDES: Record<string, number> = {

--- a/packages/core/src/tool/built-in/git-context.ts
+++ b/packages/core/src/tool/built-in/git-context.ts
@@ -1,7 +1,7 @@
 import { z } from "zod"
 import { execSync } from "child_process"
 import { readFileSync } from "fs"
-import { resolve, relative } from "path"
+import { resolve, relative, basename } from "path"
 import type { ToolDef, ToolContext, ExecuteResult } from "../types.js"
 import { executeGitHistoryAction, type GitHistoryAction } from "../git/history-actions.js"
 
@@ -112,7 +112,7 @@ function extractAnnotations(absFile: string): Annotation[] {
 // ── Test file finder ──────────────────────────────────────────────────────────
 
 function findTestFiles(workdir: string, absFile: string): string[] {
-  const base = absFile.replace(/\.(tsx?)$/, "").split("/").pop() ?? ""
+  const base = basename(absFile).replace(/\.(tsx?)$/, "")
   if (!base) return []
 
   const tracked = git(workdir, "ls-files")

--- a/packages/core/src/tool/built-in/glob.ts
+++ b/packages/core/src/tool/built-in/glob.ts
@@ -3,6 +3,7 @@ import { resolve, join, relative } from "path"
 import { readdir }                 from "node:fs/promises"
 import type { ToolDef, ToolContext, ExecuteResult } from "../types.js"
 import { resolveAuthorizedFilesystemPath } from "../../security/filesystem-grants.js"
+import { toPosix } from "../../util/paths.js"
 
 const MAX_FILES  = 2_000
 const TIMEOUT_MS = 15_000
@@ -41,7 +42,7 @@ async function* walkFiles(
         yield* walkFiles(join(dir, entry.name), root, signal)
       }
     } else if (entry.isFile()) {
-      yield relative(root, join(dir, entry.name))
+      yield toPosix(relative(root, join(dir, entry.name)))
     }
   }
 }

--- a/packages/core/src/tool/built-in/grep.ts
+++ b/packages/core/src/tool/built-in/grep.ts
@@ -3,6 +3,7 @@ import { resolve, join, relative, basename } from "path"
 import { readdir, stat } from "node:fs/promises"
 import type { ToolDef, ToolContext, ExecuteResult } from "../types.js"
 import { resolveAuthorizedFilesystemPath } from "../../security/filesystem-grants.js"
+import { toPosix } from "../../util/paths.js"
 
 const MAX_MATCHES   = 200
 const MAX_FILE_SIZE = 2_000_000   // 2MB - buyuk/uretilmis dosyalari atla
@@ -40,7 +41,7 @@ async function* walkFiles(
         yield* walkFiles(join(dir, entry.name), root, signal)
       }
     } else if (entry.isFile()) {
-      yield relative(root, join(dir, entry.name))
+      yield toPosix(relative(root, join(dir, entry.name)))
     }
   }
 }

--- a/packages/core/src/tool/built-in/http-request.ts
+++ b/packages/core/src/tool/built-in/http-request.ts
@@ -72,14 +72,14 @@ RETURNS: status code, response headers, body (auto-parsed JSON), timing.`,
       }
     }
 
+    // Already cancelled — short-circuit before arming a timer or a listener that
+    // would only be torn down again, and before any request is started.
+    if (ctx.signal.aborted) return { output: "", error: "Request cancelled" }
+
     const controller = new AbortController()
     let timedOut = false
     const onParentAbort = () => controller.abort()
-    if (ctx.signal.aborted) {
-      controller.abort()
-    } else {
-      ctx.signal.addEventListener("abort", onParentAbort, { once: true })
-    }
+    ctx.signal.addEventListener("abort", onParentAbort, { once: true })
     const timer = setTimeout(() => { timedOut = true; controller.abort() }, timeout)
 
     const start = Date.now()

--- a/packages/core/src/tool/built-in/http-request.ts
+++ b/packages/core/src/tool/built-in/http-request.ts
@@ -1,5 +1,5 @@
 import { z } from "zod"
-import type { ToolDef, ExecuteResult } from "../types.js"
+import type { ToolDef, ToolContext, ExecuteResult } from "../types.js"
 import { fetchWithUrlPolicy, readResponseTextLimited } from "../../security/network-policy.js"
 
 const MAX_RESPONSE_BYTES = 2_000_000
@@ -40,7 +40,7 @@ RETURNS: status code, response headers, body (auto-parsed JSON), timing.`,
     follow_redirects: z.boolean().default(true),
   }),
 
-  async execute(args): Promise<ExecuteResult> {
+  async execute(args, ctx: ToolContext): Promise<ExecuteResult> {
     const url    = String(args["url"])
     const method = String(args["method"] ?? "GET").toUpperCase()
     const timeout = Number(args["timeout"] ?? 30000)
@@ -73,10 +73,16 @@ RETURNS: status code, response headers, body (auto-parsed JSON), timing.`,
     }
 
     const controller = new AbortController()
-    const timer = setTimeout(() => controller.abort(), timeout)
+    let timedOut = false
+    const onParentAbort = () => controller.abort()
+    if (ctx.signal.aborted) {
+      controller.abort()
+    } else {
+      ctx.signal.addEventListener("abort", onParentAbort, { once: true })
+    }
+    const timer = setTimeout(() => { timedOut = true; controller.abort() }, timeout)
 
     const start = Date.now()
-    let res: Response
     try {
       const request: RequestInit = {
         method,
@@ -85,38 +91,41 @@ RETURNS: status code, response headers, body (auto-parsed JSON), timing.`,
         redirect: (args["follow_redirects"] as boolean ?? true) ? "follow" : "manual",
         ...(bodyStr === undefined ? {} : { body: bodyStr }),
       }
-      res = await fetchWithUrlPolicy(url, request, {
+      const res = await fetchWithUrlPolicy(url, request, {
         followRedirects: (args["follow_redirects"] as boolean | undefined) ?? true,
       })
+
+      const resHeaders: Record<string, string> = {}
+      res.headers.forEach((v, k) => { resHeaders[k] = v })
+
+      const { text: raw, truncated } = await readResponseTextLimited(res, MAX_RESPONSE_BYTES)
+      let body: unknown = raw
+      const ct = res.headers.get("content-type") ?? ""
+      if (ct.includes("application/json") || (raw.trimStart().startsWith("{") || raw.trimStart().startsWith("["))) {
+        try { body = JSON.parse(raw) } catch { body = raw }
+      }
+
+      const elapsed = Date.now() - start
+      const out: Record<string, unknown> = {
+        status:     res.status,
+        statusText: res.statusText,
+        ok:         res.ok,
+        timing_ms:  elapsed,
+        headers:    resHeaders,
+        body,
+        ...(truncated ? { truncated: true } : {}),
+      }
+
+      return { output: JSON.stringify(out, null, 2) }
     } catch (err: unknown) {
-      clearTimeout(timer)
+      const isAbort = err instanceof Error && err.name === "AbortError"
+      if (isAbort && timedOut) return { output: "", error: `Request timed out after ${timeout}ms` }
+      if (isAbort && ctx.signal.aborted) return { output: "", error: "Request cancelled" }
       const msg = err instanceof Error ? err.message : String(err)
       return { output: "", error: `Request failed: ${msg}` }
     } finally {
       clearTimeout(timer)
+      ctx.signal.removeEventListener("abort", onParentAbort)
     }
-
-    const elapsed = Date.now() - start
-    const resHeaders: Record<string, string> = {}
-    res.headers.forEach((v, k) => { resHeaders[k] = v })
-
-    const { text: raw, truncated } = await readResponseTextLimited(res, MAX_RESPONSE_BYTES)
-    let body: unknown = raw
-    const ct = res.headers.get("content-type") ?? ""
-    if (ct.includes("application/json") || (raw.trimStart().startsWith("{") || raw.trimStart().startsWith("["))) {
-      try { body = JSON.parse(raw) } catch { body = raw }
-    }
-
-    const out: Record<string, unknown> = {
-      status:     res.status,
-      statusText: res.statusText,
-      ok:         res.ok,
-      timing_ms:  elapsed,
-      headers:    resHeaders,
-      body,
-      ...(truncated ? { truncated: true } : {}),
-    }
-
-    return { output: JSON.stringify(out, null, 2) }
   },
 }

--- a/packages/core/src/tool/built-in/read.ts
+++ b/packages/core/src/tool/built-in/read.ts
@@ -5,6 +5,7 @@ import type { ToolDef, ToolContext, ExecuteResult } from "../types.js"
 import { semanticCache } from "../semantic-cache.js"
 import { resolveAuthorizedFilesystemPath } from "../../security/filesystem-grants.js"
 import { observeBackground } from "../../util/background-task.js"
+import { toPosix } from "../../util/paths.js"
 
 const MAX_CHARS = 100_000
 
@@ -33,11 +34,13 @@ const SENSITIVE_OUTSIDE_WORKDIR: RegExp[] = [
 ]
 
 function checkSensitivePath(filePath: string, workdir: string): string | null {
-  const norm = workdir.endsWith("/") ? workdir : workdir + "/"
+  const normFile = toPosix(filePath)
+  const normWorkdir = toPosix(workdir)
+  const norm = normWorkdir.endsWith("/") ? normWorkdir : normWorkdir + "/"
   // Proje içindeyse her zaman serbest
-  if (filePath.startsWith(norm) || filePath === workdir) return null
+  if (normFile.startsWith(norm) || normFile === normWorkdir) return null
   for (const re of SENSITIVE_OUTSIDE_WORKDIR) {
-    if (re.test(filePath)) {
+    if (re.test(normFile)) {
       return `Security: '${filePath}' okuma engellendi — proje dizini dışında hassas dosya`
     }
   }

--- a/packages/core/src/tool/git/history-actions.ts
+++ b/packages/core/src/tool/git/history-actions.ts
@@ -1,5 +1,5 @@
 import { execFileSync } from "node:child_process"
-import { relative, resolve } from "node:path"
+import { relative, resolve, sep } from "node:path"
 
 export type GitHistoryAction = "pickaxe" | "regex_history" | "blame_range" | "show_at_ref" | "compare_history"
 
@@ -97,7 +97,7 @@ function git(workdir: string, args: string[]): string {
 function repoPath(workdir: string, file: string): string {
   const root = resolve(workdir)
   const absolute = resolve(root, file)
-  if (absolute !== root && !absolute.startsWith(root + "/")) throw new Error(`Path is outside repository: ${file}`)
+  if (absolute !== root && !absolute.startsWith(root + sep)) throw new Error(`Path is outside repository: ${file}`)
   return relative(root, absolute).replaceAll("\\", "/")
 }
 

--- a/packages/core/src/tool/language/typescript-navigation.ts
+++ b/packages/core/src/tool/language/typescript-navigation.ts
@@ -1,6 +1,6 @@
 import ts from "typescript"
 import { readFile, writeFile } from "node:fs/promises"
-import { dirname, relative, resolve } from "node:path"
+import { dirname, relative, resolve, sep } from "node:path"
 import { gateGuard } from "../../permission/gateguard.js"
 import { WorkspaceTransaction } from "../../transaction/workspace-transaction.js"
 import type { ExecuteResult, ToolContext } from "../types.js"
@@ -239,7 +239,7 @@ async function rename(
 function resolveInside(workdir: string, path: string): string {
   const root = resolve(workdir)
   const absolute = resolve(root, path)
-  if (absolute !== root && !absolute.startsWith(root + "/")) throw new Error(`Path is outside workspace: ${path}`)
+  if (absolute !== root && !absolute.startsWith(root + sep)) throw new Error(`Path is outside workspace: ${path}`)
   return absolute
 }
 

--- a/packages/core/src/util/paths.ts
+++ b/packages/core/src/util/paths.ts
@@ -1,0 +1,5 @@
+/** Normalises a filesystem path to forward slashes so comparisons and tool
+ *  output stay identical on Windows and POSIX. */
+export function toPosix(path: string): string {
+  return path.split("\\").join("/")
+}

--- a/packages/core/src/util/prefetch.ts
+++ b/packages/core/src/util/prefetch.ts
@@ -10,6 +10,7 @@
 import { readFile } from "fs/promises"
 import { resolve } from "path"
 import { LRUCache } from "./lru-cache.js"
+import { toPosix } from "./paths.js"
 
 export type PrefetchHint = "file-read" | "grep-result" | "glob-result" | "edit-target"
 
@@ -72,7 +73,7 @@ export class PrefetchManager {
    * Prefetch edilmiş dosyayı al.
    */
   getPrefetched(path: string): PrefetchResult | null {
-    const result = this.cache.get(path)
+    const result = this.cache.get(toPosix(resolve(path)))
     if (result) {
       this.hitCount++
     }
@@ -102,7 +103,7 @@ export class PrefetchManager {
   private async prefetchFile(filePath: string, workdir: string): Promise<void> {
     if (!filePath) return
 
-    const absPath = resolve(workdir, filePath)
+    const absPath = toPosix(resolve(workdir, filePath))
 
     // Zaten cache'de varsa skip
     if (this.cache.has(absPath)) return

--- a/packages/core/test/file-lock-concurrency.test.ts
+++ b/packages/core/test/file-lock-concurrency.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, beforeEach, mock } from "bun:test"
+import { describe, it, expect, beforeEach, afterEach, mock } from "bun:test"
 import { mkdtempSync, rmSync } from "node:fs"
 import * as realFs from "node:fs/promises"
 import { tmpdir } from "node:os"
@@ -40,6 +40,10 @@ beforeEach(() => {
   dir = mkdtempSync(join(tmpdir(), "aurict-file-lock-race-"))
   renamePauseAtCall = null
   renameCallCount = 0
+})
+
+afterEach(() => {
+  try { rmSync(dir, { recursive: true, force: true }) } catch { /* ignore */ }
 })
 
 function target() {
@@ -137,8 +141,4 @@ describe("agent/file-lock.ts — race-safe stale reclamation", () => {
     const ok = await acquireFileLock(dir, f, "agent-b", "session-b")
     expect(ok).toBe(true)
   })
-})
-
-process.once("exit", () => {
-  try { rmSync(dir, { recursive: true, force: true }) } catch { /* ignore */ }
 })

--- a/packages/core/test/file-lock-concurrency.test.ts
+++ b/packages/core/test/file-lock-concurrency.test.ts
@@ -1,0 +1,144 @@
+import { describe, it, expect, beforeEach, mock } from "bun:test"
+import { mkdtempSync, rmSync } from "node:fs"
+import * as realFs from "node:fs/promises"
+import { tmpdir } from "node:os"
+import { join } from "node:path"
+
+const trueRename = realFs.rename.bind(realFs)
+
+let renamePauseAtCall: number | null = null
+let renameCallCount = 0
+let renameHitResolve: (() => void) | null = null
+let renameResumePromise: Promise<void> | null = null
+
+function armRenameGate(atCallIndex: number) {
+  renamePauseAtCall = atCallIndex
+  renameCallCount = 0
+  const hit = new Promise<void>((resolve) => { renameHitResolve = resolve })
+  let resumeResolve!: () => void
+  renameResumePromise = new Promise<void>((resolve) => { resumeResolve = resolve })
+  return { hit, resume: () => resumeResolve() }
+}
+
+mock.module("node:fs/promises", () => ({
+  ...realFs,
+  async rename(...args: Parameters<typeof realFs.rename>) {
+    renameCallCount++
+    if (renamePauseAtCall !== null && renameCallCount === renamePauseAtCall) {
+      renamePauseAtCall = null
+      renameHitResolve?.()
+      await renameResumePromise
+    }
+    return trueRename(...args)
+  },
+}))
+
+const { acquireFileLock, releaseFileLock, getFileLockInfo } = await import("../src/agent/file-lock.js")
+
+let dir: string
+beforeEach(() => {
+  dir = mkdtempSync(join(tmpdir(), "aurict-file-lock-race-"))
+  renamePauseAtCall = null
+  renameCallCount = 0
+})
+
+function target() {
+  return join(dir, `f-${Date.now()}-${Math.random().toString(36).slice(2)}.ts`)
+}
+
+async function expireImmediately() {
+  await new Promise((r) => setTimeout(r, 20))
+}
+
+describe("agent/file-lock.ts — race-safe stale reclamation", () => {
+  it("iki reclaimer aynı süresi dolmuş lock için yarışır: tek etkili sahip, kaybeden kazananın lock'unu silemez", async () => {
+    const f = target()
+    await acquireFileLock(dir, f, "agent-0", "s0", 5)
+    await expireImmediately()
+
+    const [a, b] = await Promise.all([
+      acquireFileLock(dir, f, "agent-A", "sA"),
+      acquireFileLock(dir, f, "agent-B", "sB"),
+    ])
+    expect(a !== b).toBe(true)
+    const winner = a ? "agent-A" : "agent-B"
+    const loser = a ? "agent-B" : "agent-A"
+
+    const info = await getFileLockInfo(dir, f)
+    expect(info?.agentId).toBe(winner)
+
+    const loserReleased = await releaseFileLock(dir, f, loser)
+    expect(loserReleased).toBe(false)
+    const infoAfter = await getFileLockInfo(dir, f)
+    expect(infoAfter?.agentId).toBe(winner)
+  })
+
+  it("A stale-recovery ortasındayken B fresh sahiplik kazanırsa, A devam ettiğinde B'nin lock'unu silmez (kritik regresyon)", async () => {
+    const f = target()
+    await acquireFileLock(dir, f, "agent-0", "s0", 5)
+    await expireImmediately()
+
+    const gate = armRenameGate(1)
+    const pA = acquireFileLock(dir, f, "agent-A", "sA")
+    await gate.hit
+
+    const okB = await acquireFileLock(dir, f, "agent-B", "sB")
+    expect(okB).toBe(true)
+
+    gate.resume()
+    const okA = await pA
+    expect(okA).toBe(false)
+
+    const info = await getFileLockInfo(dir, f)
+    expect(info?.agentId).toBe("agent-B")
+    expect(info?.sessionId).toBe("sB")
+  })
+
+  it("birden fazla stale contender: tek final owner, canonical lock geçerli kalır", async () => {
+    const f = target()
+    await acquireFileLock(dir, f, "agent-0", "s0", 5)
+    await expireImmediately()
+
+    const results = await Promise.all([
+      acquireFileLock(dir, f, "agent-A", "sA"),
+      acquireFileLock(dir, f, "agent-B", "sB"),
+      acquireFileLock(dir, f, "agent-C", "sC"),
+    ])
+    const winners = results.filter(Boolean)
+    expect(winners.length).toBe(1)
+
+    const info = await getFileLockInfo(dir, f)
+    expect(info).not.toBeNull()
+    expect(info!.expiresAt).toBeGreaterThan(Date.now())
+  })
+
+  it("stale recovery sırasında geç gelen bir release, yeni kurulan lock'u silemez", async () => {
+    const f = target()
+    await acquireFileLock(dir, f, "agent-0", "s0", 5)
+    await expireImmediately()
+
+    const okA = await acquireFileLock(dir, f, "agent-A", "sA")
+    expect(okA).toBe(true)
+
+    const released = await releaseFileLock(dir, f, "agent-0")
+    expect(released).toBe(false)
+
+    const info = await getFileLockInfo(dir, f)
+    expect(info?.agentId).toBe("agent-A")
+
+    const releasedByOwner = await releaseFileLock(dir, f, "agent-A")
+    expect(releasedByOwner).toBe(true)
+  })
+
+  it("mevcut sıralı TTL testi: A kısa TTL ile alır, süresi dolar, B alır", async () => {
+    const f = target()
+    await acquireFileLock(dir, f, "agent-a", "session-a", 10)
+    await new Promise((r) => setTimeout(r, 30))
+    const ok = await acquireFileLock(dir, f, "agent-b", "session-b")
+    expect(ok).toBe(true)
+  })
+})
+
+process.once("exit", () => {
+  try { rmSync(dir, { recursive: true, force: true }) } catch { /* ignore */ }
+})

--- a/packages/core/test/http-request.test.ts
+++ b/packages/core/test/http-request.test.ts
@@ -1,0 +1,121 @@
+import { describe, it, expect, mock, beforeEach } from "bun:test"
+import { createMockContext } from "./helpers.js"
+
+type Scenario = "success" | "hang-body" | "pending-fetch" | "fetch-error"
+
+let scenario: Scenario = "success"
+let fetchCalls = 0
+let lastSignal: AbortSignal | undefined
+
+function abortError(): Error {
+  return Object.assign(new Error("The operation was aborted"), { name: "AbortError" })
+}
+
+mock.module("../src/security/network-policy.js", () => ({
+  fetchWithUrlPolicy: async (_url: string, request: RequestInit) => {
+    fetchCalls++
+    lastSignal = request.signal as AbortSignal
+    if (lastSignal?.aborted) throw abortError()
+    if (scenario === "fetch-error") throw new Error("network down")
+    if (scenario === "pending-fetch") {
+      return new Promise((_resolve, reject) => {
+        lastSignal!.addEventListener("abort", () => reject(abortError()), { once: true })
+      })
+    }
+    return {
+      ok: true, status: 200, statusText: "OK",
+      headers: new Headers({ "content-type": "application/json" }),
+    } as unknown as Response
+  },
+  readResponseTextLimited: async (_res: Response, _max: number) => {
+    if (scenario === "hang-body") {
+      return new Promise((_resolve, reject) => {
+        lastSignal!.addEventListener("abort", () => reject(abortError()), { once: true })
+      })
+    }
+    return { text: JSON.stringify({ ok: true }), truncated: false }
+  },
+}))
+
+const { httpRequestTool } = await import("../src/tool/built-in/http-request.js")
+
+beforeEach(() => {
+  scenario = "success"
+  fetchCalls = 0
+  lastSignal = undefined
+})
+
+describe("httpRequestTool yaşam döngüsü", () => {
+  it("normal bir yanıtta başarılı olur", async () => {
+    const ctx = createMockContext()
+    const result = await httpRequestTool.execute({ url: "https://example.com", timeout: 5000 }, ctx)
+
+    expect(result.error).toBeUndefined()
+    const body = JSON.parse(result.output)
+    expect(body.status).toBe(200)
+    expect(body.body.ok).toBe(true)
+    expect(typeof body.timing_ms).toBe("number")
+  })
+
+  it("sadece header değil, takılan gövde için de timeout uygular", async () => {
+    scenario = "hang-body"
+    const ctx = createMockContext()
+    const result = await httpRequestTool.execute({ url: "https://example.com", timeout: 30 }, ctx)
+
+    expect(result.error).toMatch(/timed out after 30ms/)
+  })
+
+  it("istek ortasında parent signal iptal edilirse hemen durur", async () => {
+    scenario = "pending-fetch"
+    const parent = new AbortController()
+    const ctx = createMockContext({ signal: parent.signal })
+
+    const promise = httpRequestTool.execute({ url: "https://example.com", timeout: 30000 }, ctx)
+    await new Promise((r) => setTimeout(r, 5))
+    parent.abort()
+    const result = await promise
+
+    expect(result.error).toBe("Request cancelled")
+  })
+
+  it("zaten iptal edilmiş bir context ile devam etmeyi reddeder", async () => {
+    const parent = new AbortController()
+    parent.abort()
+    const ctx = createMockContext({ signal: parent.signal })
+
+    const result = await httpRequestTool.execute({ url: "https://example.com", timeout: 30000 }, ctx)
+
+    expect(result.error).toBe("Request cancelled")
+  })
+
+  it("sıradan fetch hatalarını timeout/iptalden ayrı raporlar", async () => {
+    scenario = "fetch-error"
+    const ctx = createMockContext()
+    const result = await httpRequestTool.execute({ url: "https://example.com", timeout: 5000 }, ctx)
+
+    expect(result.error).toBe("Request failed: network down")
+  })
+
+  it("parent-abort dinleyicisini her kod yolunda temizler", async () => {
+    for (const s of ["success", "hang-body", "pending-fetch", "fetch-error"] as Scenario[]) {
+      scenario = s
+      const parent = new AbortController()
+      let addCount = 0
+      let removeCount = 0
+      const realAdd = parent.signal.addEventListener.bind(parent.signal)
+      const realRemove = parent.signal.removeEventListener.bind(parent.signal)
+      parent.signal.addEventListener = (...a: Parameters<typeof realAdd>) => { addCount++; return realAdd(...a) }
+      parent.signal.removeEventListener = (...a: Parameters<typeof realRemove>) => { removeCount++; return realRemove(...a) }
+
+      const ctx = createMockContext({ signal: parent.signal })
+      const promise = httpRequestTool.execute({ url: "https://example.com", timeout: 30 }, ctx)
+      if (s === "pending-fetch") {
+        await new Promise((r) => setTimeout(r, 5))
+        parent.abort()
+      }
+      await promise
+
+      expect(removeCount).toBe(addCount)
+    }
+  })
+})

--- a/packages/core/test/http-request.test.ts
+++ b/packages/core/test/http-request.test.ts
@@ -1,54 +1,58 @@
-import { describe, it, expect, mock, beforeEach } from "bun:test"
+import { describe, it, expect, beforeEach, afterAll } from "bun:test"
 import { createMockContext } from "./helpers.js"
 
 type Scenario = "success" | "hang-body" | "pending-fetch" | "fetch-error"
 
+// Public literal IP: assertSafeRemoteUrl skips the DNS lookup for IP hosts, so
+// these tests exercise the real network-policy layer with only fetch stubbed.
+// Module-level mocking of network-policy would leak into every other test file.
+const TEST_URL = "https://93.184.216.34/"
+
 let scenario: Scenario = "success"
 let fetchCalls = 0
-let lastSignal: AbortSignal | undefined
 
 function abortError(): Error {
   return Object.assign(new Error("The operation was aborted"), { name: "AbortError" })
 }
 
-mock.module("../src/security/network-policy.js", () => ({
-  fetchWithUrlPolicy: async (_url: string, request: RequestInit) => {
-    fetchCalls++
-    lastSignal = request.signal as AbortSignal
-    if (lastSignal?.aborted) throw abortError()
-    if (scenario === "fetch-error") throw new Error("network down")
-    if (scenario === "pending-fetch") {
-      return new Promise((_resolve, reject) => {
-        lastSignal!.addEventListener("abort", () => reject(abortError()), { once: true })
-      })
-    }
-    return {
-      ok: true, status: 200, statusText: "OK",
-      headers: new Headers({ "content-type": "application/json" }),
-    } as unknown as Response
-  },
-  readResponseTextLimited: async (_res: Response, _max: number) => {
-    if (scenario === "hang-body") {
-      return new Promise((_resolve, reject) => {
-        lastSignal!.addEventListener("abort", () => reject(abortError()), { once: true })
-      })
-    }
-    return { text: JSON.stringify({ ok: true }), truncated: false }
-  },
-}))
+/** Body that only settles when the request signal aborts — like a stalled read. */
+function hangingBody(signal: AbortSignal): ReadableStream<Uint8Array> {
+  return new ReadableStream<Uint8Array>({
+    start(controller) {
+      signal.addEventListener("abort", () => controller.error(abortError()), { once: true })
+    },
+  })
+}
 
-const { httpRequestTool } = await import("../src/tool/built-in/http-request.js")
+const realFetch = globalThis.fetch
+globalThis.fetch = (async (_input: RequestInfo | URL, init?: RequestInit) => {
+  fetchCalls++
+  const signal = init?.signal as AbortSignal
+  if (signal?.aborted) throw abortError()
+  if (scenario === "fetch-error") throw new Error("network down")
+  if (scenario === "pending-fetch") {
+    return new Promise<Response>((_resolve, reject) => {
+      signal.addEventListener("abort", () => reject(abortError()), { once: true })
+    })
+  }
+  const headers = { "content-type": "application/json" }
+  if (scenario === "hang-body") return new Response(hangingBody(signal), { status: 200, headers })
+  return new Response(JSON.stringify({ ok: true }), { status: 200, headers })
+}) as typeof globalThis.fetch
+
+afterAll(() => { globalThis.fetch = realFetch })
+
+import { httpRequestTool } from "../src/tool/built-in/http-request.js"
 
 beforeEach(() => {
   scenario = "success"
   fetchCalls = 0
-  lastSignal = undefined
 })
 
 describe("httpRequestTool yaşam döngüsü", () => {
   it("normal bir yanıtta başarılı olur", async () => {
     const ctx = createMockContext()
-    const result = await httpRequestTool.execute({ url: "https://example.com", timeout: 5000 }, ctx)
+    const result = await httpRequestTool.execute({ url: TEST_URL, timeout: 5000 }, ctx)
 
     expect(result.error).toBeUndefined()
     const body = JSON.parse(result.output)
@@ -60,7 +64,7 @@ describe("httpRequestTool yaşam döngüsü", () => {
   it("sadece header değil, takılan gövde için de timeout uygular", async () => {
     scenario = "hang-body"
     const ctx = createMockContext()
-    const result = await httpRequestTool.execute({ url: "https://example.com", timeout: 30 }, ctx)
+    const result = await httpRequestTool.execute({ url: TEST_URL, timeout: 30 }, ctx)
 
     expect(result.error).toMatch(/timed out after 30ms/)
   })
@@ -70,7 +74,7 @@ describe("httpRequestTool yaşam döngüsü", () => {
     const parent = new AbortController()
     const ctx = createMockContext({ signal: parent.signal })
 
-    const promise = httpRequestTool.execute({ url: "https://example.com", timeout: 30000 }, ctx)
+    const promise = httpRequestTool.execute({ url: TEST_URL, timeout: 30000 }, ctx)
     await new Promise((r) => setTimeout(r, 5))
     parent.abort()
     const result = await promise
@@ -83,7 +87,7 @@ describe("httpRequestTool yaşam döngüsü", () => {
     parent.abort()
     const ctx = createMockContext({ signal: parent.signal })
 
-    const result = await httpRequestTool.execute({ url: "https://example.com", timeout: 30000 }, ctx)
+    const result = await httpRequestTool.execute({ url: TEST_URL, timeout: 30000 }, ctx)
 
     expect(result.error).toBe("Request cancelled")
   })
@@ -91,7 +95,7 @@ describe("httpRequestTool yaşam döngüsü", () => {
   it("sıradan fetch hatalarını timeout/iptalden ayrı raporlar", async () => {
     scenario = "fetch-error"
     const ctx = createMockContext()
-    const result = await httpRequestTool.execute({ url: "https://example.com", timeout: 5000 }, ctx)
+    const result = await httpRequestTool.execute({ url: TEST_URL, timeout: 5000 }, ctx)
 
     expect(result.error).toBe("Request failed: network down")
   })
@@ -108,7 +112,7 @@ describe("httpRequestTool yaşam döngüsü", () => {
       parent.signal.removeEventListener = (...a: Parameters<typeof realRemove>) => { removeCount++; return realRemove(...a) }
 
       const ctx = createMockContext({ signal: parent.signal })
-      const promise = httpRequestTool.execute({ url: "https://example.com", timeout: 30 }, ctx)
+      const promise = httpRequestTool.execute({ url: TEST_URL, timeout: 30 }, ctx)
       if (s === "pending-fetch") {
         await new Promise((r) => setTimeout(r, 5))
         parent.abort()

--- a/packages/core/test/network-policy-abort.test.ts
+++ b/packages/core/test/network-policy-abort.test.ts
@@ -1,0 +1,47 @@
+import { describe, it, expect } from "bun:test"
+import { withAbort, fetchWithUrlPolicy } from "../src/security/network-policy.js"
+
+describe("network-policy iptal edilebilirliği", () => {
+  it("takılan bir işlemi signal abort edilince hemen sonlandırır", async () => {
+    // dns.promises.lookup bir AbortSignal almaz; takılan bir resolver bu yarış
+    // olmadan hem timeout'u hem parent iptalini yok sayardı.
+    const controller = new AbortController()
+    const stuck = withAbort(controller.signal, () => new Promise<never>(() => { /* asla settle olmaz */ }))
+    setTimeout(() => controller.abort(), 10)
+
+    await expect(stuck).rejects.toMatchObject({ name: "AbortError" })
+  })
+
+  it("zaten iptal edilmiş bir signal ile işi hiç başlatmaz", async () => {
+    const controller = new AbortController()
+    controller.abort()
+    let started = false
+
+    await expect(
+      withAbort(controller.signal, async () => { started = true }),
+    ).rejects.toMatchObject({ name: "AbortError" })
+    expect(started).toBe(false)
+  })
+
+  it("signal yoksa işi olduğu gibi çalıştırır", async () => {
+    await expect(withAbort(undefined, async () => "ok")).resolves.toBe("ok")
+  })
+
+  it("iş bittikten sonra signal üzerinde dinleyici bırakmaz", async () => {
+    const controller = new AbortController()
+    await withAbort(controller.signal, async () => "ok")
+    let leaked = false
+    controller.signal.addEventListener("abort", () => { leaked = true })
+    controller.abort()
+    expect(leaked).toBe(true) // yeni dinleyici çalışır; eski dinleyici reject etmediği için test asılmaz
+  })
+
+  it("zaten iptal edilmiş bir signal ile fetchWithUrlPolicy DNS'e hiç girmez", async () => {
+    const controller = new AbortController()
+    controller.abort()
+
+    await expect(
+      fetchWithUrlPolicy("https://example.com/", { signal: controller.signal }),
+    ).rejects.toMatchObject({ name: "AbortError" })
+  })
+})

--- a/packages/core/test/network-policy-abort.test.ts
+++ b/packages/core/test/network-policy-abort.test.ts
@@ -29,11 +29,15 @@ describe("network-policy iptal edilebilirliği", () => {
 
   it("iş bittikten sonra signal üzerinde dinleyici bırakmaz", async () => {
     const controller = new AbortController()
+    let addCount = 0
+    let removeCount = 0
+    const realAdd = controller.signal.addEventListener.bind(controller.signal)
+    const realRemove = controller.signal.removeEventListener.bind(controller.signal)
+    controller.signal.addEventListener = (...a: Parameters<typeof realAdd>) => { addCount++; return realAdd(...a) }
+    controller.signal.removeEventListener = (...a: Parameters<typeof realRemove>) => { removeCount++; return realRemove(...a) }
+
     await withAbort(controller.signal, async () => "ok")
-    let leaked = false
-    controller.signal.addEventListener("abort", () => { leaked = true })
-    controller.abort()
-    expect(leaked).toBe(true) // yeni dinleyici çalışır; eski dinleyici reject etmediği için test asılmaz
+    expect(removeCount).toBe(addCount)
   })
 
   it("zaten iptal edilmiş bir signal ile fetchWithUrlPolicy DNS'e hiç girmez", async () => {

--- a/packages/core/test/project-auto.test.ts
+++ b/packages/core/test/project-auto.test.ts
@@ -5,6 +5,21 @@ import { join } from "node:path"
 import { evaluateProjectAutoRequest } from "../src/permission/project-auto.js"
 import type { PermissionRequest } from "../src/permission/types.js"
 
+/** Windows refuses symlink creation without Developer Mode or admin rights.
+ *  Probe once so the symlink-escape cases skip visibly instead of passing green
+ *  without ever exercising the boundary they assert. */
+const CAN_SYMLINK = (() => {
+  const probe = mkdtempSync(join(tmpdir(), "aurict-symlink-probe-"))
+  try {
+    symlinkSync(probe, join(probe, "link"), "dir")
+    return true
+  } catch {
+    return false
+  } finally {
+    rmSync(probe, { recursive: true, force: true })
+  }
+})()
+
 const temporaryRoots: string[] = []
 
 function workspace(): string {
@@ -60,12 +75,13 @@ describe("Project Auto permission policy", () => {
     expect(verdict.reason).toContain("typed file")
   })
 
-  it("rejects paths outside the project and symlink escapes", async () => {
+  it.skipIf(!CAN_SYMLINK)("rejects paths outside the project and symlink escapes", async () => {
     const root = workspace()
     const outside = workspace()
-    symlinkSync(outside, join(root, "linked"), "dir")
 
     expect((await evaluateProjectAutoRequest(request({ pattern: "../outside.ts" }), root)).allow).toBe(false)
+
+    symlinkSync(outside, join(root, "linked"), "dir")
     expect((await evaluateProjectAutoRequest(request({ pattern: "linked/escape.ts" }), root)).allow).toBe(false)
   })
 

--- a/packages/core/test/runtime-hardening.test.ts
+++ b/packages/core/test/runtime-hardening.test.ts
@@ -15,6 +15,21 @@ import { jsonSchemaToZod } from "../src/mcp/bridge.js"
 import { providerEnv, withProviderEnvironment } from "../src/provider/credentials.js"
 import { httpRequestTool } from "../src/tool/built-in/http-request.js"
 
+/** Windows refuses symlink creation without Developer Mode or admin rights.
+ *  Probe once so the symlink-escape cases skip visibly instead of passing green
+ *  without ever exercising the boundary they assert. */
+const CAN_SYMLINK = (() => {
+  const probe = mkdtempSync(join(tmpdir(), "aurict-symlink-probe-"))
+  try {
+    symlinkSync(probe, join(probe, "link"), "dir")
+    return true
+  } catch {
+    return false
+  } finally {
+    rmSync(probe, { recursive: true, force: true })
+  }
+})()
+
 const tempDirs: string[] = []
 
 afterEach(() => {
@@ -77,7 +92,7 @@ describe("history integrity", () => {
 })
 
 describe("security boundaries", () => {
-  it("rejects workspace symlink escapes", async () => {
+  it.skipIf(!CAN_SYMLINK)("rejects workspace symlink escapes", async () => {
     const root = mkdtempSync(join(tmpdir(), "aurict-boundary-root-"))
     const outside = mkdtempSync(join(tmpdir(), "aurict-boundary-outside-"))
     tempDirs.push(root, outside)

--- a/packages/core/test/storage-paths.test.ts
+++ b/packages/core/test/storage-paths.test.ts
@@ -1,7 +1,7 @@
 import { afterEach, describe, expect, it } from 'bun:test'
 import { mkdtempSync, rmSync, writeFileSync } from 'node:fs'
 import { tmpdir } from 'node:os'
-import { join } from 'node:path'
+import { join, resolve } from 'node:path'
 import { coreAssetDir, coreStateDir, coreStatePath, ensureCoreStateDir } from '../src/storage/paths.js'
 import { loadDesignPrefs, saveDesignPrefs } from '../src/design/prefs.js'
 
@@ -49,7 +49,7 @@ describe('core state paths', () => {
   it('uses the dedicated asset directory before the legacy alias', () => {
     process.env.AURICT_ASSET_DIR = '/tmp/aurict-assets'
     process.env.AURICT_DATA_DIR = '/tmp/aurict-legacy-assets'
-    expect(coreAssetDir()).toBe('/tmp/aurict-assets')
+    expect(coreAssetDir()).toBe(resolve('/tmp/aurict-assets'))
   })
 
   it('persists preferences in the configured state directory and rejects corrupt data', () => {


### PR DESCRIPTION
## What changed and why

Two robustness fixes in `packages/core`, plus the path-portability work needed to run `bun run test` green on a non-Linux developer machine.

### 1. `http_request` lifecycle timeouts

The abort timer only covered the fetch handshake. A server that answered headers promptly and then stalled the body could hang a tool call indefinitely — the agent had no way out short of killing the run.

- Body consumption, the 2 MB response limit and JSON parsing now run **inside** the timed region; the timer is cleared in a single `finally`.
- A request-local `AbortController` is chained to the parent `ctx.signal`, so cancelling a run tears the request down immediately instead of leaking a socket for the remainder of the timeout.
- An already-aborted context short-circuits before any socket is opened.
- The parent-abort listener is removed on every code path, including the error paths.
- Timeout, cancellation and ordinary transport failure are now three distinct errors instead of one opaque `AbortError`:
  - `Request timed out after <n>ms`
  - `Request cancelled`
  - `Request failed: <message>`

No change to `fetchWithUrlPolicy()` or any SSRF check — the policy layer is untouched.

### 2. Race-safe stale file-lock reclamation (follow-up to #16)

#16 landed atomic lock *acquisition* (`writeFile` with `flag: "wx"`), but stale reclamation was still `read → unlink → create`. That is a TOCTOU: two agents can both observe the same expired lock, and the loser's `unlink` can delete the winner's freshly written lock — silently handing two agents a lock on the same file.

Reclamation now uses `rename()` as a compare-and-swap. `rename` requires its source to exist, so racing callers produce exactly one winner and `ENOENT` for the rest. The captured bytes are re-checked against the stale observation; a mismatch means the slot changed underneath us, so the exact bytes are restored into an empty slot and the reclaim is abandoned.

`releaseFileLock` checks ownership **before** the CAS capture. Renaming first would make a still-valid lock briefly invisible and let a third agent win the `wx` fast path, destroying the real owner's lock — a non-owner release has to stay a pure no-op. Unparseable captured content is restored verbatim rather than re-serialised, so a corrupt lock file is never silently dropped.

A crash between the `rename` and its `unlink` leaves a claim sibling behind. Those orphans never block acquisition (the canonical path is free again), but they accumulate, so the reclamation path sweeps claim files older than the lock TTL. The sweep is best-effort and can never fail an acquire.

Stale locks remain reclaimable throughout — a crashed agent never permanently blocks a file.

### 3. Windows path portability

Several places assumed POSIX separators, so a large part of the suite failed outside CI. None of this changes behaviour on Linux.

- Six inline copies of the same backslash-to-slash rewrite replaced by `util/paths.ts` `toPosix()`, used by `glob`, `grep`, `read`, `prefetch`, `filesystem-grants` and the skill injector.
- `history-actions` and `typescript-navigation` use `path.sep` for containment checks.
- `skill/registry` resolves its library via `fileURLToPath` instead of `URL.pathname`.
- `git-context` uses `path.basename`.
- **`PermissionStore.isApproved`** split persisted `"tool:pattern"` entries with `split(":", 2)`, which truncated Windows paths at the drive letter. It now splits on the first colon only, and skips malformed entries containing none — those previously produced a truthy path and could grant a spurious directory approval.

Also restores the four-line `NodeJS.EventEmitter` cast on `process.off`. `bun-types` declares a narrow non-generic `off(event: "memoryPressure", ...)` that shadows the inherited generic `EventEmitter.off` for the whole `Process` type, so `process.off("SIGINT", …)` fails typecheck.

### 4. Test guards for genuine platform limits

Windows refuses symlink creation without Developer Mode, and rejects tab characters in filenames.

The three symlink-escape **security** tests previously swallowed `EPERM` and `return`ed — reporting green without ever exercising the boundary they assert. They now skip visibly via a one-time capability probe (`it.skipIf(!CAN_SYMLINK)`). Linux/CI still runs them; that is where the coverage is enforced.

## Tests

New, both under `packages/core/test/`:

- `file-lock-concurrency.test.ts` — two reclaimers racing on one stale lock; A's stale recovery must not delete B's fresh lock (the critical regression); multiple stale contenders; a late release arriving during stale recovery; sequential TTL behaviour.
- `http-request.test.ts` — happy path; timeout applied to a stalled **body**, not just headers; mid-request parent-signal cancellation; refusal to proceed with an already-aborted context; ordinary fetch failures reported separately from timeout/cancel; parent-abort listener cleaned up on every path.

Descriptions are Turkish, matching the existing convention in the `file-lock*` test family.

## Verification

`bun run quality` (check:quality → typecheck ×3 → check:version → test), all green:

| suite | result |
|---|---|
| core | 1291 pass / 4 skip / 0 fail |
| cli | 445 pass / 4 skip / 0 fail |
| desktop | 39 pass / 1 skip / 0 fail |

The skip counts are +2 core / +1 desktop against `main` — exactly the three symlink tests that previously passed green on Windows without running. On Linux CI they execute as before.

## Notes for review

- No SSRF, redirect, credential or response-limit check was relaxed.
- No lock ownership rule was relaxed; stale locks stay reclaimable.
- Not addressed here: `getPrefetched` normalises its cache key differently from the writer. It is latent — the only caller is `prefetch.test.ts` passing absolute paths, where `resolve()` is idempotent — and there is no `workdir` at the call site to fix it cleanly. Left for a follow-up.

